### PR TITLE
Ensure WAL entries use newline terminators

### DIFF
--- a/test_wal.py
+++ b/test_wal.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+import unittest
+
+from wal import WriteAheadLog
+
+class WriteAheadLogTest(unittest.TestCase):
+    def test_append_writes_newlines_and_read_all(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            wal_path = os.path.join(tmpdir, "wal.txt")
+            wal = WriteAheadLog(wal_path)
+            wal.append("PUT", "k1", "v1")
+            wal.append("PUT", "k2", "v2")
+
+            # Ensure each entry was written on its own line
+            with open(wal_path, "r") as f:
+                lines = f.readlines()
+            self.assertEqual(len(lines), 2)
+
+            # Ensure read_all parses entries correctly
+            entries = wal.read_all()
+            self.assertEqual(len(entries), 2)
+            self.assertEqual(entries[0][1:], ("PUT", "k1", "v1"))
+            self.assertEqual(entries[1][1:], ("PUT", "k2", "v2"))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/wal.py
+++ b/wal.py
@@ -21,7 +21,7 @@ class WriteAheadLog(object):
         timestamp = int(time.time() * 1000) # ms
         entry = f"{timestamp}|{entry_type}|{key}|{value}"
         with open(self.wal_file_path, 'a') as file:
-            file.write(entry)
+            file.write(entry + "\n")
 
     def read_all(self):
         """Lê todas as entradas do WAL (para recuperação de falhas)."""


### PR DESCRIPTION
## Summary
- fix `WriteAheadLog.append` to write records each on new line
- add unit test confirming newline separated WAL entries are parsed correctly

## Testing
- `python -m py_compile wal.py lsm_db.py mem_table.py replication.py sstable.py main.py test_wal.py`
- `python -m unittest test_wal.py -v`


------
https://chatgpt.com/codex/tasks/task_e_6844d5dcaef08331a89b43263af06e86