### PR TITLE
Refactor heartbeat into reusable classes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 grpcio
 grpcio-tools
+grpcio-health-checking


### PR DESCRIPTION
## Summary
- encapsulate replica server logic in `NodeServer`
- share heartbeat handling through new `HeartbeatService`
- add gRPC health server on each node
- update leader heartbeat server to use the shared service
- include `grpcio-health-checking` in dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846e00b769c8331aead8fae0af791ea