### PR TITLE
Add timestamp support in MemTable and WAL

### DIFF
--- a/mem_table.py
+++ b/mem_table.py
@@ -149,11 +149,11 @@ class MemTable:
 
     # API pública compatível
     def put(self, key, value):
-        """Insere ou atualiza um par chave-valor."""
+        """Insere ou atualiza um par ``(valor, timestamp)``."""
         self._tree.insert(key, value)
 
     def get(self, key):
-        """Retorna valor associado à chave."""
+        """Retorna ``(valor, timestamp)`` associado à chave."""
         return self._tree.search(key)
 
     def is_full(self):

--- a/tests/test_lsm_db.py
+++ b/tests/test_lsm_db.py
@@ -48,5 +48,14 @@ class SimpleLSMDBTest(unittest.TestCase):
             self.assertEqual(db2.get('k1'), 'v1')
             db2.close()
 
+    def test_get_record(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SimpleLSMDB(db_path=tmpdir, max_memtable_size=10)
+            db.put('k1', 'v1')
+            value, ts = db.get_record('k1')
+            self.assertEqual(value, 'v1')
+            self.assertIsInstance(ts, int)
+            db.close()
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -23,8 +23,10 @@ class WriteAheadLogTest(unittest.TestCase):
             # Ensure read_all parses entries correctly
             entries = wal.read_all()
             self.assertEqual(len(entries), 2)
-            self.assertEqual(entries[0][1:], ("PUT", "k1", "v1"))
-            self.assertEqual(entries[1][1:], ("PUT", "k2", "v2"))
+            t1, e1, k1, v1 = entries[0]
+            t2, e2, k2, v2 = entries[1]
+            self.assertEqual((e1, k1, v1[0], v1[1]), ("PUT", "k1", "v1", t1))
+            self.assertEqual((e2, k2, v2[0], v2[1]), ("PUT", "k2", "v2", t2))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `SimpleLSMDB.put` and `delete` with optional `timestamp`
- keep `(value, timestamp)` pairs in the `MemTable`
- persist timestamp info in WAL entries and expose `get_record`
- adjust tests for WAL and database behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1a8330308331be5fdea6154f7cf1