### PR TITLE
Add Lamport clocks to node server

### DIFF
--- a/lamport.py
+++ b/lamport.py
@@ -1,0 +1,14 @@
+class LamportClock:
+    """Simple Lamport logical clock."""
+    def __init__(self, start: int = 0) -> None:
+        self.time = int(start)
+
+    def tick(self) -> int:
+        """Advance the clock for a local event."""
+        self.time += 1
+        return self.time
+
+    def update(self, external_timestamp: int) -> int:
+        """Merge an external timestamp and advance."""
+        self.time = max(self.time, int(external_timestamp)) + 1
+        return self.time

--- a/replication.py
+++ b/replication.py
@@ -20,8 +20,11 @@ class GRPCReplicaClient:
         self.stub = replication_pb2_grpc.ReplicaStub(self.channel)
         self.hb_stub = replication_pb2_grpc.HeartbeatServiceStub(self.channel)
 
-    def put(self, key, value):
-        request = replication_pb2.KeyValue(key=key, value=value)
+    def put(self, key, value, timestamp=None):
+        if timestamp is None:
+            import time
+            timestamp = int(time.time() * 1000)
+        request = replication_pb2.KeyValue(key=key, value=value, timestamp=timestamp)
         self.stub.Put(request)
 
     def delete(self, key):


### PR DESCRIPTION
## Summary
- implement simple `LamportClock`
- manage clock in `NodeServer` and update on write RPCs
- send timestamp in GRPC client PUT requests

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1c0a2a208331b80c64ba11d1a8e4