### PR TITLE
Implement FetchUpdates RPC and peer sync

### DIFF
--- a/replica/client.py
+++ b/replica/client.py
@@ -36,5 +36,9 @@ class GRPCReplicaClient:
         response = self.stub.Get(request)
         return response.value if response.value else None
 
+    def fetch_updates(self, last_seen: dict):
+        vv = replication_pb2.VersionVector(items=last_seen)
+        return self.stub.FetchUpdates(vv)
+
     def close(self):
         self.channel.close()

--- a/replica/replication.proto
+++ b/replica/replication.proto
@@ -34,11 +34,32 @@ message Heartbeat {
   string node_id = 1;
 }
 
+// Vetor de versões enviado ao requisitar atualizações
+message VersionVector {
+  map<string, int64> items = 1;
+}
+
+// Representa uma operação pendente de replicação
+message Operation {
+  string key = 1;
+  string value = 2;
+  int64 timestamp = 3;
+  string node_id = 4;
+  string op_id = 5;
+  bool delete = 6;
+}
+
+// Lista de operações para sincronização
+message FetchResponse {
+  repeated Operation ops = 1;
+}
+
 // Servico disponibilizado por cada seguidor
 service Replica {
   rpc Put(KeyValue) returns (Empty);
   rpc Delete(KeyRequest) returns (Empty);
   rpc Get(KeyRequest) returns (ValueResponse);
+  rpc FetchUpdates(VersionVector) returns (FetchResponse);
 }
 
 // Servico dedicado para heartbeat

--- a/replica/replication_pb2.py
+++ b/replica/replication_pb2.py
@@ -24,13 +24,15 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"L\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\"Y\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\"\x1e\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t2\xae\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"L\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\"Y\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\"\x1e\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"j\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\"4\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation2\xf6\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x46\n\x0c\x46\x65tchUpdates\x12\x1a.replication.VersionVector\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'replication_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
+  _globals['_VERSIONVECTOR_ITEMSENTRY']._loaded_options = None
+  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_options = b'8\001'
   _globals['_KEYREQUEST']._serialized_start=34
   _globals['_KEYREQUEST']._serialized_end=110
   _globals['_KEYVALUE']._serialized_start=112
@@ -41,8 +43,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_EMPTY']._serialized_end=242
   _globals['_HEARTBEAT']._serialized_start=244
   _globals['_HEARTBEAT']._serialized_end=272
-  _globals['_REPLICA']._serialized_start=275
-  _globals['_REPLICA']._serialized_end=449
-  _globals['_HEARTBEATSERVICE']._serialized_start=451
-  _globals['_HEARTBEATSERVICE']._serialized_end=521
+  _globals['_VERSIONVECTOR']._serialized_start=274
+  _globals['_VERSIONVECTOR']._serialized_end=389
+  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_start=345
+  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_end=389
+  _globals['_OPERATION']._serialized_start=391
+  _globals['_OPERATION']._serialized_end=497
+  _globals['_FETCHRESPONSE']._serialized_start=499
+  _globals['_FETCHRESPONSE']._serialized_end=551
+  _globals['_REPLICA']._serialized_start=554
+  _globals['_REPLICA']._serialized_end=800
+  _globals['_HEARTBEATSERVICE']._serialized_start=802
+  _globals['_HEARTBEATSERVICE']._serialized_end=872
 # @@protoc_insertion_point(module_scope)

--- a/replica/replication_pb2_grpc.py
+++ b/replica/replication_pb2_grpc.py
@@ -50,6 +50,11 @@ class ReplicaStub(object):
                 request_serializer=replication__pb2.KeyRequest.SerializeToString,
                 response_deserializer=replication__pb2.ValueResponse.FromString,
                 _registered_method=True)
+        self.FetchUpdates = channel.unary_unary(
+                '/replication.Replica/FetchUpdates',
+                request_serializer=replication__pb2.VersionVector.SerializeToString,
+                response_deserializer=replication__pb2.FetchResponse.FromString,
+                _registered_method=True)
 
 
 class ReplicaServicer(object):
@@ -74,6 +79,12 @@ class ReplicaServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def FetchUpdates(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_ReplicaServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -91,6 +102,11 @@ def add_ReplicaServicer_to_server(servicer, server):
                     servicer.Get,
                     request_deserializer=replication__pb2.KeyRequest.FromString,
                     response_serializer=replication__pb2.ValueResponse.SerializeToString,
+            ),
+            'FetchUpdates': grpc.unary_unary_rpc_method_handler(
+                    servicer.FetchUpdates,
+                    request_deserializer=replication__pb2.VersionVector.FromString,
+                    response_serializer=replication__pb2.FetchResponse.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -175,6 +191,33 @@ class Replica(object):
             '/replication.Replica/Get',
             replication__pb2.KeyRequest.SerializeToString,
             replication__pb2.ValueResponse.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def FetchUpdates(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_unary(
+            request,
+            target,
+            '/replication.Replica/FetchUpdates',
+            replication__pb2.VersionVector.SerializeToString,
+            replication__pb2.FetchResponse.FromString,
             options,
             channel_credentials,
             insecure,


### PR DESCRIPTION
## Summary
- define `FetchUpdates` RPC for synchronization
- regenerate gRPC bindings
- implement new RPC on server
- expose `fetch_updates()` in client
- use `sync_from_peer()` on startup

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684c513028a48331a96ee42d5b53babe