### PR TITLE
Add anti-entropy thread and batch replication

### DIFF
--- a/replica/client.py
+++ b/replica/client.py
@@ -36,9 +36,12 @@ class GRPCReplicaClient:
         response = self.stub.Get(request)
         return response.value if response.value else None
 
-    def fetch_updates(self, last_seen: dict):
+    def fetch_updates(self, last_seen: dict, ops=None):
+        """Fetch updates from peer optionally sending our pending ops."""
         vv = replication_pb2.VersionVector(items=last_seen)
-        return self.stub.FetchUpdates(vv)
+        ops = ops or []
+        req = replication_pb2.FetchRequest(vector=vv, ops=ops)
+        return self.stub.FetchUpdates(req)
 
     def close(self):
         self.channel.close()

--- a/replica/replication.proto
+++ b/replica/replication.proto
@@ -49,6 +49,12 @@ message Operation {
   bool delete = 6;
 }
 
+// Requisição para anti-entropy permitindo enviar várias operações
+message FetchRequest {
+  VersionVector vector = 1;
+  repeated Operation ops = 2;
+}
+
 // Lista de operações para sincronização
 message FetchResponse {
   repeated Operation ops = 1;
@@ -59,7 +65,7 @@ service Replica {
   rpc Put(KeyValue) returns (Empty);
   rpc Delete(KeyRequest) returns (Empty);
   rpc Get(KeyRequest) returns (ValueResponse);
-  rpc FetchUpdates(VersionVector) returns (FetchResponse);
+  rpc FetchUpdates(FetchRequest) returns (FetchResponse);
 }
 
 // Servico dedicado para heartbeat

--- a/replica/replication_pb2.py
+++ b/replica/replication_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"L\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\"Y\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\"\x1e\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"j\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\"4\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation2\xf6\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x46\n\x0c\x46\x65tchUpdates\x12\x1a.replication.VersionVector\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"L\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\"Y\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\"\x1e\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"j\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\"_\n\x0c\x46\x65tchRequest\x12*\n\x06vector\x18\x01 \x01(\x0b\x32\x1a.replication.VersionVector\x12#\n\x03ops\x18\x02 \x03(\x0b\x32\x16.replication.Operation\"4\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation2\xf5\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x45\n\x0c\x46\x65tchUpdates\x12\x19.replication.FetchRequest\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -49,10 +49,12 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_end=389
   _globals['_OPERATION']._serialized_start=391
   _globals['_OPERATION']._serialized_end=497
-  _globals['_FETCHRESPONSE']._serialized_start=499
-  _globals['_FETCHRESPONSE']._serialized_end=551
-  _globals['_REPLICA']._serialized_start=554
-  _globals['_REPLICA']._serialized_end=800
-  _globals['_HEARTBEATSERVICE']._serialized_start=802
-  _globals['_HEARTBEATSERVICE']._serialized_end=872
+  _globals['_FETCHREQUEST']._serialized_start=499
+  _globals['_FETCHREQUEST']._serialized_end=594
+  _globals['_FETCHRESPONSE']._serialized_start=596
+  _globals['_FETCHRESPONSE']._serialized_end=648
+  _globals['_REPLICA']._serialized_start=651
+  _globals['_REPLICA']._serialized_end=896
+  _globals['_HEARTBEATSERVICE']._serialized_start=898
+  _globals['_HEARTBEATSERVICE']._serialized_end=968
 # @@protoc_insertion_point(module_scope)

--- a/replica/replication_pb2_grpc.py
+++ b/replica/replication_pb2_grpc.py
@@ -52,7 +52,7 @@ class ReplicaStub(object):
                 _registered_method=True)
         self.FetchUpdates = channel.unary_unary(
                 '/replication.Replica/FetchUpdates',
-                request_serializer=replication__pb2.VersionVector.SerializeToString,
+                request_serializer=replication__pb2.FetchRequest.SerializeToString,
                 response_deserializer=replication__pb2.FetchResponse.FromString,
                 _registered_method=True)
 
@@ -105,7 +105,7 @@ def add_ReplicaServicer_to_server(servicer, server):
             ),
             'FetchUpdates': grpc.unary_unary_rpc_method_handler(
                     servicer.FetchUpdates,
-                    request_deserializer=replication__pb2.VersionVector.FromString,
+                    request_deserializer=replication__pb2.FetchRequest.FromString,
                     response_serializer=replication__pb2.FetchResponse.SerializeToString,
             ),
     }
@@ -216,7 +216,7 @@ class Replica(object):
             request,
             target,
             '/replication.Replica/FetchUpdates',
-            replication__pb2.VersionVector.SerializeToString,
+            replication__pb2.FetchRequest.SerializeToString,
             replication__pb2.FetchResponse.FromString,
             options,
             channel_credentials,

--- a/tests/test_replica_service.py
+++ b/tests/test_replica_service.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 import unittest
+import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -83,6 +84,74 @@ class ReplicaServiceSequenceTest(unittest.TestCase):
             self.assertEqual(node.db.get("k"), "v2")
 
             node.db.close()
+
+
+class FetchUpdatesTest(unittest.TestCase):
+    def test_fetch_updates_apply_and_return(self):
+        with tempfile.TemporaryDirectory() as dir_a, tempfile.TemporaryDirectory() as dir_b:
+            node_a = NodeServer(db_path=dir_a, node_id="A")
+            node_b = NodeServer(db_path=dir_b, node_id="B")
+            service_a = ReplicaService(node_a)
+
+            # Operation from node B to be applied on node A
+            op_b = replication_pb2.Operation(
+                key="k1",
+                value="v1",
+                timestamp=1,
+                node_id="B",
+                op_id="B:1",
+                delete=False,
+            )
+
+            # Node A has a pending operation to send back
+            node_a.replication_log["A:1"] = ("k2", "v2", 2)
+
+            req = replication_pb2.FetchRequest(
+                vector=replication_pb2.VersionVector(items={}),
+                ops=[op_b],
+            )
+
+            resp = service_a.FetchUpdates(req, None)
+
+            self.assertEqual(node_a.db.get("k1"), "v1")
+            self.assertEqual(len(resp.ops), 1)
+            self.assertEqual(resp.ops[0].key, "k2")
+            self.assertEqual(resp.ops[0].op_id, "A:1")
+
+            node_a.db.close()
+            node_b.db.close()
+
+
+class AntiEntropyLoopTest(unittest.TestCase):
+    def test_anti_entropy_loop_syncs_nodes(self):
+        with tempfile.TemporaryDirectory() as dir_a, tempfile.TemporaryDirectory() as dir_b:
+            node_a = NodeServer(db_path=dir_a, node_id="A", peers=[])
+            node_b = NodeServer(db_path=dir_b, node_id="B", peers=[])
+            service_b = ReplicaService(node_b)
+
+            node_b.replication_log["B:1"] = ("k", "v", 5)
+
+            class FakeClient:
+                def fetch_updates(self, last_seen, ops=None):
+                    vv = replication_pb2.VersionVector(items=last_seen)
+                    req = replication_pb2.FetchRequest(vector=vv, ops=ops or [])
+                    return service_b.FetchUpdates(req, None)
+
+                def close(self):
+                    pass
+
+            node_a.peer_clients = [FakeClient()]
+            node_a.anti_entropy_interval = 0.1
+            node_a._start_anti_entropy_thread()
+
+            time.sleep(0.3)
+            node_a._anti_entropy_stop.set()
+            node_a._anti_entropy_thread.join()
+
+            self.assertEqual(node_a.db.get("k"), "v")
+
+            node_a.db.close()
+            node_b.db.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `FetchRequest` message to support batching
- allow Replica service `FetchUpdates` to apply incoming operations
- implement anti-entropy loop in `NodeServer`
- batch operations when syncing/replaying logs
- update gRPC client for the new request type

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c5372c71083318b089aeeee9999b2