### PR TITLE
Add Merkle tree sync

### DIFF
--- a/merkle.py
+++ b/merkle.py
@@ -1,0 +1,49 @@
+"""Merkle tree utilities for SimpleLSMDB."""
+import os
+import hashlib
+from typing import List, Tuple, Dict
+
+
+def _hash(data: str) -> str:
+    return hashlib.sha256(data.encode('utf-8')).hexdigest()
+
+
+def merkle_root(items: List[Tuple[str, str]]) -> str:
+    """Compute Merkle root hash for given key/value pairs."""
+    leaves = [_hash(f"{k}:{v}") for k, v in sorted(items)]
+    if not leaves:
+        return _hash("")
+    while len(leaves) > 1:
+        if len(leaves) % 2 == 1:
+            leaves.append(leaves[-1])
+        next_level = []
+        for i in range(0, len(leaves), 2):
+            next_level.append(_hash(leaves[i] + leaves[i + 1]))
+        leaves = next_level
+    return leaves[0]
+
+
+def compute_segment_hashes(db) -> Dict[str, str]:
+    """Return merkle root for memtable and each SSTable segment."""
+    hashes: Dict[str, str] = {}
+
+    # memtable
+    if hasattr(db, "memtable"):
+        items = [(k, v[0]) for k, v in db.memtable.get_sorted_items()]
+        hashes["memtable"] = merkle_root(items)
+
+    if hasattr(db, "sstable_manager"):
+        for _, path, _ in db.sstable_manager.sstable_segments:
+            seg_id = os.path.basename(path)
+            seg_items: List[Tuple[str, str]] = []
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    for line in f:
+                        if ":" not in line:
+                            continue
+                        k, v = line.strip().split(":", 1)
+                        seg_items.append((k, v))
+            except FileNotFoundError:
+                continue
+            hashes[seg_id] = merkle_root(seg_items)
+    return hashes

--- a/replica/client.py
+++ b/replica/client.py
@@ -36,11 +36,12 @@ class GRPCReplicaClient:
         response = self.stub.Get(request)
         return response.value if response.value else None
 
-    def fetch_updates(self, last_seen: dict, ops=None):
-        """Fetch updates from peer optionally sending our pending ops."""
+    def fetch_updates(self, last_seen: dict, ops=None, segment_hashes=None):
+        """Fetch updates from peer optionally sending our pending ops and hashes."""
         vv = replication_pb2.VersionVector(items=last_seen)
         ops = ops or []
-        req = replication_pb2.FetchRequest(vector=vv, ops=ops)
+        hashes = segment_hashes or {}
+        req = replication_pb2.FetchRequest(vector=vv, ops=ops, segment_hashes=hashes)
         return self.stub.FetchUpdates(req)
 
     def close(self):

--- a/replica/replication.proto
+++ b/replica/replication.proto
@@ -53,11 +53,13 @@ message Operation {
 message FetchRequest {
   VersionVector vector = 1;
   repeated Operation ops = 2;
+  map<string, string> segment_hashes = 3;
 }
 
 // Lista de operações para sincronização
 message FetchResponse {
   repeated Operation ops = 1;
+  map<string, string> segment_hashes = 2;
 }
 
 // Servico disponibilizado por cada seguidor

--- a/replica/replication_pb2.py
+++ b/replica/replication_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"L\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\"Y\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\"\x1e\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"j\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\"_\n\x0c\x46\x65tchRequest\x12*\n\x06vector\x18\x01 \x01(\x0b\x32\x1a.replication.VersionVector\x12#\n\x03ops\x18\x02 \x03(\x0b\x32\x16.replication.Operation\"4\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation2\xf5\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x45\n\x0c\x46\x65tchUpdates\x12\x19.replication.FetchRequest\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"L\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\"Y\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\"\x1e\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"j\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\"\xdb\x01\n\x0c\x46\x65tchRequest\x12*\n\x06vector\x18\x01 \x01(\x0b\x32\x1a.replication.VersionVector\x12#\n\x03ops\x18\x02 \x03(\x0b\x32\x16.replication.Operation\x12\x44\n\x0esegment_hashes\x18\x03 \x03(\x0b\x32,.replication.FetchRequest.SegmentHashesEntry\x1a\x34\n\x12SegmentHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb1\x01\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation\x12\x45\n\x0esegment_hashes\x18\x02 \x03(\x0b\x32-.replication.FetchResponse.SegmentHashesEntry\x1a\x34\n\x12SegmentHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\xf5\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x45\n\x0c\x46\x65tchUpdates\x12\x19.replication.FetchRequest\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,6 +33,10 @@ if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
   _globals['_VERSIONVECTOR_ITEMSENTRY']._loaded_options = None
   _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_options = b'8\001'
+  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._loaded_options = None
+  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_options = b'8\001'
+  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._loaded_options = None
+  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_options = b'8\001'
   _globals['_KEYREQUEST']._serialized_start=34
   _globals['_KEYREQUEST']._serialized_end=110
   _globals['_KEYVALUE']._serialized_start=112
@@ -49,12 +53,16 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_end=389
   _globals['_OPERATION']._serialized_start=391
   _globals['_OPERATION']._serialized_end=497
-  _globals['_FETCHREQUEST']._serialized_start=499
-  _globals['_FETCHREQUEST']._serialized_end=594
-  _globals['_FETCHRESPONSE']._serialized_start=596
-  _globals['_FETCHRESPONSE']._serialized_end=648
-  _globals['_REPLICA']._serialized_start=651
-  _globals['_REPLICA']._serialized_end=896
-  _globals['_HEARTBEATSERVICE']._serialized_start=898
-  _globals['_HEARTBEATSERVICE']._serialized_end=968
+  _globals['_FETCHREQUEST']._serialized_start=500
+  _globals['_FETCHREQUEST']._serialized_end=719
+  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_start=667
+  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_end=719
+  _globals['_FETCHRESPONSE']._serialized_start=722
+  _globals['_FETCHRESPONSE']._serialized_end=899
+  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_start=667
+  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_end=719
+  _globals['_REPLICA']._serialized_start=902
+  _globals['_REPLICA']._serialized_end=1147
+  _globals['_HEARTBEATSERVICE']._serialized_start=1149
+  _globals['_HEARTBEATSERVICE']._serialized_end=1219
 # @@protoc_insertion_point(module_scope)

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -1,0 +1,80 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lsm_db import SimpleLSMDB
+from merkle import merkle_root, compute_segment_hashes
+from replica.grpc_server import ReplicaService, NodeServer
+from replica import replication_pb2
+
+
+class MerkleUtilsTest(unittest.TestCase):
+    def test_compute_hashes_after_flush(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SimpleLSMDB(db_path=tmpdir, max_memtable_size=2)
+            db.put("a", "1")
+            db.recalc_merkle()
+            before = db.segment_hashes["memtable"]
+            db.put("b", "2")  # triggers flush
+            seg_names = [os.path.basename(p) for _, p, _ in db.sstable_manager.sstable_segments]
+            self.assertEqual(len(seg_names), 1)
+            hashes = db.segment_hashes
+            self.assertNotEqual(before, hashes["memtable"])
+            expected = merkle_root([("a", "1"), ("b", "2")])
+            self.assertEqual(hashes[seg_names[0]], expected)
+            db.close()
+
+
+class FetchUpdatesMerkleTest(unittest.TestCase):
+    def test_matching_segment_hashes_skip_transfer(self):
+        with tempfile.TemporaryDirectory() as dir_a, tempfile.TemporaryDirectory() as dir_b:
+            node_a = NodeServer(db_path=dir_a, node_id="A")
+            node_b = NodeServer(db_path=dir_b, node_id="B")
+            service_b = ReplicaService(node_b)
+
+            node_a.db.put("k", "v")
+            node_b.db.put("k", "v")
+            node_a.db.recalc_merkle()
+            node_b.db.recalc_merkle()
+
+            req = replication_pb2.FetchRequest(
+                vector=replication_pb2.VersionVector(items={}),
+                ops=[],
+                segment_hashes=node_a.db.segment_hashes,
+            )
+            resp = service_b.FetchUpdates(req, None)
+            self.assertEqual(len(resp.ops), 0)
+
+            node_a.db.close()
+            node_b.db.close()
+
+    def test_different_segment_hashes_send_diffs(self):
+        with tempfile.TemporaryDirectory() as dir_a, tempfile.TemporaryDirectory() as dir_b:
+            node_a = NodeServer(db_path=dir_a, node_id="A")
+            node_b = NodeServer(db_path=dir_b, node_id="B")
+            service_b = ReplicaService(node_b)
+
+            node_a.db.put("k1", "v1")
+            node_b.db.put("k1", "v1")
+            node_b.db.put("k2", "v2")
+            node_a.db.recalc_merkle()
+            node_b.db.recalc_merkle()
+
+            req = replication_pb2.FetchRequest(
+                vector=replication_pb2.VersionVector(items={}),
+                ops=[],
+                segment_hashes=node_a.db.segment_hashes,
+            )
+            resp = service_b.FetchUpdates(req, None)
+            keys = sorted(op.key for op in resp.ops)
+            self.assertEqual(keys, ["k1", "k2"])
+
+            node_a.db.close()
+            node_b.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_replica_service.py
+++ b/tests/test_replica_service.py
@@ -132,9 +132,9 @@ class AntiEntropyLoopTest(unittest.TestCase):
             node_b.replication_log["B:1"] = ("k", "v", 5)
 
             class FakeClient:
-                def fetch_updates(self, last_seen, ops=None):
+                def fetch_updates(self, last_seen, ops=None, segment_hashes=None):
                     vv = replication_pb2.VersionVector(items=last_seen)
-                    req = replication_pb2.FetchRequest(vector=vv, ops=ops or [])
+                    req = replication_pb2.FetchRequest(vector=vv, ops=ops or [], segment_hashes=segment_hashes or {})
                     return service_b.FetchUpdates(req, None)
 
                 def close(self):


### PR DESCRIPTION
## Summary
- implement `merkle.py` with basic utilities
- compute hashes in `SimpleLSMDB` after flush and compaction
- extend gRPC protocol to transmit segment hashes
- update Node server and client to compare Merkle trees
- add tests covering Merkle hashes and sync logic

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_684c57b6e4a48331a9e1d8a761856a59