### PR TITLE
Support node_id for peer clients

### DIFF
--- a/replication.py
+++ b/replication.py
@@ -47,7 +47,10 @@ class NodeCluster:
 
         base_port = 9000
         self.nodes = []
-        peers = [("localhost", base_port + i) for i in range(num_nodes)]
+        peers = [
+            ("localhost", base_port + i, f"node_{i}")
+            for i in range(num_nodes)
+        ]
 
         for i in range(num_nodes):
             node_id = f"node_{i}"


### PR DESCRIPTION
## Summary
- allow `NodeServer` to handle 3‑tuple `(host, port, node_id)` peer configs
- expose peers through `clients_by_id`
- adjust peer iteration helpers
- include node ids when spinning up `NodeCluster`

## Testing
- `pip install -r requirements.txt`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c67cfeb4c833199a5e8301464d698