### PR TITLE
Update next_op_id to track local progress

### DIFF
--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -307,6 +307,7 @@ class NodeServer:
     def next_op_id(self) -> str:
         """Return next operation identifier."""
         self.local_seq += 1
+        self.last_seen[self.node_id] = self.local_seq
         return f"{self.node_id}:{self.local_seq}"
 
     def cleanup_replication_log(self) -> None:


### PR DESCRIPTION
## Summary
- refresh own last_seen entry whenever next_op_id is generated

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c69aae8b08331a8b38f0c8033de23