### PR TITLE
Add VectorClock support in NodeServer

### DIFF
--- a/vector_clock.py
+++ b/vector_clock.py
@@ -1,0 +1,39 @@
+class VectorClock:
+    """Simple vector clock implementation."""
+
+    def __init__(self, initial=None):
+        self.clock = dict(initial) if initial else {}
+
+    def increment(self, node_id: str) -> int:
+        """Increment counter for given node and return new value."""
+        self.clock[node_id] = self.clock.get(node_id, 0) + 1
+        return self.clock[node_id]
+
+    def merge(self, other: "VectorClock") -> None:
+        """Merge another vector clock into this one taking max of counters."""
+        for node, counter in other.clock.items():
+            if counter > self.clock.get(node, 0):
+                self.clock[node] = counter
+
+    def compare(self, other: "VectorClock") -> str | None:
+        """Compare two vector clocks.
+
+        Returns '>' if this clock is causally after ``other``,
+        '<' if it is causally before ``other`` or ``None`` if
+        they are concurrent or equal.
+        """
+        greater = False
+        less = False
+        nodes = set(self.clock) | set(other.clock)
+        for node in nodes:
+            a = self.clock.get(node, 0)
+            b = other.clock.get(node, 0)
+            if a > b:
+                greater = True
+            elif a < b:
+                less = True
+        if greater and not less:
+            return ">"
+        if less and not greater:
+            return "<"
+        return None


### PR DESCRIPTION
## Summary
- implement simple `VectorClock`
- store `VectorClock` in `NodeServer`
- keep vector state when loading `last_seen`
- increment vector clock when creating operation IDs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c784947508331b2a60e9af682ad54