### PR TITLE
Implement vector clock storage

### DIFF
--- a/tests/test_lsm_db.py
+++ b/tests/test_lsm_db.py
@@ -6,6 +6,7 @@ import unittest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from lsm_db import SimpleLSMDB
+from vector_clock import VectorClock
 
 class SimpleLSMDBTest(unittest.TestCase):
     def test_put_get_and_flush(self):
@@ -52,9 +53,11 @@ class SimpleLSMDBTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             db = SimpleLSMDB(db_path=tmpdir, max_memtable_size=10)
             db.put('k1', 'v1')
-            value, ts = db.get_record('k1')
+            records = db.get_record('k1')
+            self.assertEqual(len(records), 1)
+            value, vc = records[0]
             self.assertEqual(value, 'v1')
-            self.assertIsInstance(ts, int)
+            self.assertIsInstance(vc, VectorClock)
             db.close()
 
 if __name__ == '__main__':

--- a/tests/test_replica_service.py
+++ b/tests/test_replica_service.py
@@ -8,6 +8,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from replica.grpc_server import NodeServer, ReplicaService
 from replica import replication_pb2
+from vector_clock import VectorClock
 
 
 class ReplicaServiceTimestampTest(unittest.TestCase):

--- a/tests/test_wal.py
+++ b/tests/test_wal.py
@@ -6,6 +6,7 @@ import unittest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from wal import WriteAheadLog
+from vector_clock import VectorClock
 
 class WriteAheadLogTest(unittest.TestCase):
     def test_append_writes_newlines_and_read_all(self):
@@ -25,8 +26,10 @@ class WriteAheadLogTest(unittest.TestCase):
             self.assertEqual(len(entries), 2)
             t1, e1, k1, v1 = entries[0]
             t2, e2, k2, v2 = entries[1]
-            self.assertEqual((e1, k1, v1[0], v1[1]), ("PUT", "k1", "v1", t1))
-            self.assertEqual((e2, k2, v2[0], v2[1]), ("PUT", "k2", "v2", t2))
+            self.assertEqual((e1, k1, v1[0]), ("PUT", "k1", "v1"))
+            self.assertIsInstance(v1[1], VectorClock)
+            self.assertEqual((e2, k2, v2[0]), ("PUT", "k2", "v2"))
+            self.assertIsInstance(v2[1], VectorClock)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- accept optional timestamp parameter and store updates using vector clocks
- convert timestamps to vector clocks in ReplicaService
- adapt merkle test expectations for new record format
- return vector clock info from get_record and adjust tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c7add26e483319f5dd11a84dfebcc