### PR TITLE
Add CRDT support with GCounter and ORSet

### DIFF
--- a/crdt.py
+++ b/crdt.py
@@ -1,0 +1,81 @@
+import time
+import json
+
+class GCounter:
+    """Grow-only counter with per-replica state."""
+
+    def __init__(self, replica_id: str, state: dict | None = None) -> None:
+        self.replica_id = replica_id
+        self.state = dict(state) if state else {}
+
+    @property
+    def value(self) -> int:
+        return sum(self.state.values())
+
+    def apply(self, amount: int = 1) -> None:
+        """Apply a local increment operation."""
+        self.state[self.replica_id] = self.state.get(self.replica_id, 0) + int(amount)
+
+    def merge(self, other: "GCounter") -> None:
+        """Merge another counter by taking maximum counts per replica."""
+        for rid, val in other.state.items():
+            if val > self.state.get(rid, 0):
+                self.state[rid] = val
+
+    def to_dict(self) -> dict:
+        return dict(self.state)
+
+    @classmethod
+    def from_dict(cls, replica_id: str, data: dict) -> "GCounter":
+        return cls(replica_id, state=data)
+
+
+class ORSet:
+    """Observed-remove set."""
+
+    def __init__(self, replica_id: str, adds=None, removes=None) -> None:
+        self.replica_id = replica_id
+        self.adds = {e: set(tags) for e, tags in (adds or {}).items()}
+        self.removes = {e: set(tags) for e, tags in (removes or {}).items()}
+
+    def _next_tag(self) -> str:
+        return f"{self.replica_id}:{int(time.time()*1000)}"
+
+    @property
+    def value(self) -> set:
+        res = set()
+        for e, tags in self.adds.items():
+            if tags - self.removes.get(e, set()):
+                res.add(e)
+        return res
+
+    def apply(self, op: dict) -> None:
+        """Apply a local add/remove operation."""
+        if op.get("op") == "add":
+            elem = op["element"]
+            tag = op.get("tag", self._next_tag())
+            self.adds.setdefault(elem, set()).add(tag)
+        elif op.get("op") == "remove":
+            elem = op["element"]
+            tags = self.adds.get(elem, set())
+            if tags:
+                self.removes.setdefault(elem, set()).update(tags)
+
+    def merge(self, other: "ORSet") -> None:
+        """Merge another OR-Set by uniting add/remove sets."""
+        for e, tags in other.adds.items():
+            self.adds.setdefault(e, set()).update(tags)
+        for e, tags in other.removes.items():
+            self.removes.setdefault(e, set()).update(tags)
+
+    def to_dict(self) -> dict:
+        return {
+            "adds": {e: list(tags) for e, tags in self.adds.items()},
+            "removes": {e: list(tags) for e, tags in self.removes.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, replica_id: str, data: dict) -> "ORSet":
+        adds = {e: set(tags) for e, tags in data.get("adds", {}).items()}
+        removes = {e: set(tags) for e, tags in data.get("removes", {}).items()}
+        return cls(replica_id, adds=adds, removes=removes)

--- a/tests/test_crdt.py
+++ b/tests/test_crdt.py
@@ -1,0 +1,47 @@
+import tempfile
+import json
+import unittest
+
+from crdt import GCounter, ORSet
+from replica.grpc_server import NodeServer, ReplicaService
+from replica import replication_pb2
+
+
+class GCounterUnitTest(unittest.TestCase):
+    def test_merge(self):
+        a = GCounter("A")
+        b = GCounter("B")
+        a.apply(2)
+        b.apply(3)
+        a.merge(b)
+        b.merge(a)
+        self.assertEqual(a.value, 5)
+        self.assertEqual(b.value, 5)
+
+
+class ReplicaServiceCRDTTest(unittest.TestCase):
+    def test_gcounter_replication(self):
+        with tempfile.TemporaryDirectory() as dir_a, tempfile.TemporaryDirectory() as dir_b:
+            cfg = {"c": "gcounter"}
+            node_a = NodeServer(db_path=dir_a, node_id="A", peers=[], crdt_config=cfg)
+            node_b = NodeServer(db_path=dir_b, node_id="B", peers=[], crdt_config=cfg)
+            service_a = ReplicaService(node_a)
+            service_b = ReplicaService(node_b)
+
+            node_a.apply_crdt("c", 1)
+            op_id, (k, v, ts) = list(node_a.replication_log.items())[-1]
+            req = replication_pb2.KeyValue(key=k, value=v, timestamp=ts, node_id="A", op_id=op_id)
+            service_b.Put(req, None)
+            self.assertEqual(node_b.crdts["c"].value, 1)
+
+            node_b.apply_crdt("c", 2)
+            op_id_b, (k2, v2, ts2) = list(node_b.replication_log.items())[-1]
+            req2 = replication_pb2.KeyValue(key=k2, value=v2, timestamp=ts2, node_id="B", op_id=op_id_b)
+            service_a.Put(req2, None)
+
+            self.assertEqual(node_a.crdts["c"].value, 3)
+            self.assertEqual(node_b.crdts["c"].value, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add simple CRDT implementations (`GCounter` and `ORSet`)
- allow NodeServer to initialise CRDT types per key
- merge CRDT values instead of creating new versions when applying replication
- expose helper `NodeServer.apply_crdt`
- add tests covering CRDT behaviour

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8177a4408331bea1fedc5bf0967b