### PR TITLE
Add concurrency tests for vector clocks and CRDT counters

### DIFF
--- a/tests/test_crdt_counter.py
+++ b/tests/test_crdt_counter.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replica.grpc_server import NodeServer, ReplicaService
+from replica import replication_pb2
+
+
+class CRDTCounterConcurrentTest(unittest.TestCase):
+    def test_concurrent_increments(self):
+        with tempfile.TemporaryDirectory() as dir_a, tempfile.TemporaryDirectory() as dir_b:
+            cfg = {"cnt": "gcounter"}
+            node_a = NodeServer(db_path=dir_a, node_id="A", peers=[], crdt_config=cfg, consistency_mode="crdt")
+            node_b = NodeServer(db_path=dir_b, node_id="B", peers=[], crdt_config=cfg, consistency_mode="crdt")
+            service_a = ReplicaService(node_a)
+            service_b = ReplicaService(node_b)
+
+            node_a.apply_crdt("cnt", 1)
+            node_b.apply_crdt("cnt", 1)
+
+            op_id_a, (k_a, v_a, ts_a) = list(node_a.replication_log.items())[-1]
+            req_a = replication_pb2.KeyValue(key=k_a, value=v_a, timestamp=ts_a, node_id="A", op_id=op_id_a)
+            service_b.Put(req_a, None)
+
+            op_id_b, (k_b, v_b, ts_b) = list(node_b.replication_log.items())[-1]
+            req_b = replication_pb2.KeyValue(key=k_b, value=v_b, timestamp=ts_b, node_id="B", op_id=op_id_b)
+            service_a.Put(req_b, None)
+
+            self.assertEqual(node_a.crdts["cnt"].value, 2)
+            self.assertEqual(node_b.crdts["cnt"].value, 2)
+
+            node_a.db.close()
+            node_b.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vector_clock.py
+++ b/tests/test_vector_clock.py
@@ -1,0 +1,38 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from lsm_db import SimpleLSMDB
+from vector_clock import VectorClock
+
+
+class VectorClockMergeTest(unittest.TestCase):
+    def test_concurrent_writes_merge(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db = SimpleLSMDB(db_path=tmpdir, max_memtable_size=10)
+
+            vc_a = VectorClock({'A': 1})
+            vc_b = VectorClock({'B': 1})
+            db.put('k', 'va', vector_clock=vc_a)
+            db.put('k', 'vb', vector_clock=vc_b)
+
+            records = db.get_record('k')
+            self.assertEqual(len(records), 2)
+            values = sorted(v for v, _ in records)
+            self.assertEqual(values, ['va', 'vb'])
+
+            vc_merge = VectorClock({'A': 1, 'B': 1})
+            db.put('k', 'va', vector_clock=vc_merge)
+
+            records = db.get_record('k')
+            self.assertEqual(len(records), 1)
+            self.assertEqual(records[0][0], 'va')
+
+            db.close()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- test concurrent vector clock updates converge after merge
- test concurrent increments on CRDT GCounter

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684c92b5d3a883318574f6b764af376d