### PR TITLE
Add consistent hashing ring to NodeCluster

### DIFF
--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -257,6 +257,8 @@ class NodeServer:
         port=8000,
         node_id="node",
         peers=None,
+        ring=None,
+        replication_factor: int = 3,
         consistency_mode: str = "lww",
         anti_entropy_interval: float = 5.0,
         max_batch_size: int = 50,
@@ -268,6 +270,8 @@ class NodeServer:
         self.port = port
         self.node_id = node_id
         self.peers = peers or []
+        self.ring = ring
+        self.replication_factor = replication_factor
         self.consistency_mode = consistency_mode
         self.crdt_config = crdt_config or {}
 
@@ -660,6 +664,8 @@ def run_server(
     port=8000,
     node_id="node",
     peers=None,
+    ring=None,
+    replication_factor: int = 3,
     *,
     consistency_mode: str = "lww",
 ):
@@ -669,6 +675,8 @@ def run_server(
         port,
         node_id=node_id,
         peers=peers,
+        ring=ring,
+        replication_factor=replication_factor,
         consistency_mode=consistency_mode,
     )
     node.start()


### PR DESCRIPTION
## Summary
- build a consistent hash ring when creating `NodeCluster`
- pass ring and replication_factor to each node
- determine coordinator node using the ring for put/get/delete
- update `NodeServer` and `run_server` signatures to accept ring info

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c99613fc48331abe2699ae14e608c