### PR TITLE
Use ring for replication coordination

### DIFF
--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -97,16 +97,17 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
                 )
                 if preferred and preferred[0] != self._node.node_id:
                     is_coordinator = False
-            op_id = request.op_id
-            if not op_id:
-                op_id = self._node.next_op_id()
-                self._node.replication_log[op_id] = (
-                    request.key,
-                    request.value,
-                    request.timestamp,
-                )
-                self._node.save_replication_log()
+
             if is_coordinator:
+                op_id = request.op_id
+                if not op_id:
+                    op_id = self._node.next_op_id()
+                    self._node.replication_log[op_id] = (
+                        request.key,
+                        request.value,
+                        request.timestamp,
+                    )
+                    self._node.save_replication_log()
                 self._node.replicate(
                     "PUT",
                     request.key,
@@ -173,12 +174,17 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
                 )
                 if preferred and preferred[0] != self._node.node_id:
                     is_coordinator = False
-            op_id = request.op_id
-            if not op_id:
-                op_id = self._node.next_op_id()
-                self._node.replication_log[op_id] = (request.key, None, request.timestamp)
-                self._node.save_replication_log()
+
             if is_coordinator:
+                op_id = request.op_id
+                if not op_id:
+                    op_id = self._node.next_op_id()
+                    self._node.replication_log[op_id] = (
+                        request.key,
+                        None,
+                        request.timestamp,
+                    )
+                    self._node.save_replication_log()
                 self._node.replicate(
                     "DELETE",
                     request.key,

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -55,15 +55,17 @@ class ReplicationManagerTest(unittest.TestCase):
             cluster = NodeCluster(base_path=tmpdir, num_nodes=2)
 
             try:
+                coord_id = cluster.ring.get_preference_list("key", 1)[0]
+                coord = cluster.nodes_by_id[coord_id]
                 t1 = multiprocessing.Process(
-                    target=cluster.nodes[0].client.put,
+                    target=coord.client.put,
                     args=("key", "v1"),
-                    kwargs={"timestamp": 1, "node_id": cluster.nodes[0].node_id},
+                    kwargs={"timestamp": 1, "node_id": coord.node_id},
                 )
                 t2 = multiprocessing.Process(
-                    target=cluster.nodes[1].client.put,
+                    target=coord.client.put,
                     args=("key", "v2"),
-                    kwargs={"timestamp": 2, "node_id": cluster.nodes[1].node_id},
+                    kwargs={"timestamp": 2, "node_id": coord.node_id},
                 )
                 t1.start()
                 t2.start()


### PR DESCRIPTION
## Summary
- ensure only the coordinator replicates PUT/DELETE
- update concurrent replication test to send writes to the coordinator

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684caf05fc088331850844b7bb6182e0