### PR TITLE
Add hinted handoff support and sloppy quorum

### DIFF
--- a/replica/client.py
+++ b/replica/client.py
@@ -11,7 +11,16 @@ class GRPCReplicaClient:
         self.stub = replication_pb2_grpc.ReplicaStub(self.channel)
         self.heartbeat_stub = replication_pb2_grpc.HeartbeatServiceStub(self.channel)
 
-    def put(self, key, value, timestamp=None, node_id="", op_id="", vector=None):
+    def put(
+        self,
+        key,
+        value,
+        timestamp=None,
+        node_id="",
+        op_id="",
+        vector=None,
+        hinted_for="",
+    ):
         if timestamp is None:
             timestamp = int(time.time() * 1000)
         if vector is None:
@@ -27,10 +36,11 @@ class GRPCReplicaClient:
             node_id=node_id,
             op_id=op_id,
             vector=vv,
+            hinted_for=hinted_for,
         )
         self.stub.Put(request)
 
-    def delete(self, key, timestamp=None, node_id="", op_id="", vector=None):
+    def delete(self, key, timestamp=None, node_id="", op_id="", vector=None, hinted_for=""):
         if timestamp is None:
             timestamp = int(time.time() * 1000)
         if vector is None:
@@ -45,6 +55,7 @@ class GRPCReplicaClient:
             node_id=node_id,
             op_id=op_id,
             vector=vv,
+            hinted_for=hinted_for,
         )
         self.stub.Delete(request)
 

--- a/replica/replication.proto
+++ b/replica/replication.proto
@@ -11,6 +11,7 @@ message KeyRequest {
   string node_id = 3;
   string op_id = 4;
   VersionVector vector = 5;
+  string hinted_for = 6;
 }
 
 // Estrutura para enviar chave e valor de uma escrita
@@ -21,6 +22,7 @@ message KeyValue {
   string node_id = 4;
   string op_id = 5;
   VersionVector vector = 6;
+  string hinted_for = 7;
 }
 
 // Resposta que devolve um valor, vazio caso nao encontrado

--- a/replica/replication_pb2.py
+++ b/replica/replication_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"x\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\x12*\n\x06vector\x18\x05 \x01(\x0b\x32\x1a.replication.VersionVector\"\x85\x01\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12*\n\x06vector\x18\x06 \x01(\x0b\x32\x1a.replication.VersionVector\"]\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12*\n\x06vector\x18\x03 \x01(\x0b\x32\x1a.replication.VersionVector\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"\x96\x01\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\x12*\n\x06vector\x18\x07 \x01(\x0b\x32\x1a.replication.VersionVector\"\xdb\x01\n\x0c\x46\x65tchRequest\x12*\n\x06vector\x18\x01 \x01(\x0b\x32\x1a.replication.VersionVector\x12#\n\x03ops\x18\x02 \x03(\x0b\x32\x16.replication.Operation\x12\x44\n\x0esegment_hashes\x18\x03 \x03(\x0b\x32,.replication.FetchRequest.SegmentHashesEntry\x1a\x34\n\x12SegmentHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb1\x01\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation\x12\x45\n\x0esegment_hashes\x18\x02 \x03(\x0b\x32-.replication.FetchResponse.SegmentHashesEntry\x1a\x34\n\x12SegmentHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\xf5\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x45\n\x0c\x46\x65tchUpdates\x12\x19.replication.FetchRequest\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11replication.proto\x12\x0breplication\"\x8c\x01\n\nKeyRequest\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12\r\n\x05op_id\x18\x04 \x01(\t\x12*\n\x06vector\x18\x05 \x01(\x0b\x32\x1a.replication.VersionVector\x12\x12\n\nhinted_for\x18\x06 \x01(\t\"\x99\x01\n\x08KeyValue\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12*\n\x06vector\x18\x06 \x01(\x0b\x32\x1a.replication.VersionVector\x12\x12\n\nhinted_for\x18\x07 \x01(\t\"]\n\rValueResponse\x12\r\n\x05value\x18\x01 \x01(\t\x12\x11\n\ttimestamp\x18\x02 \x01(\x03\x12*\n\x06vector\x18\x03 \x01(\x0b\x32\x1a.replication.VersionVector\"\x07\n\x05\x45mpty\"\x1c\n\tHeartbeat\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"s\n\rVersionVector\x12\x34\n\x05items\x18\x01 \x03(\x0b\x32%.replication.VersionVector.ItemsEntry\x1a,\n\nItemsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x03:\x02\x38\x01\"\x96\x01\n\tOperation\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\r\n\x05op_id\x18\x05 \x01(\t\x12\x0e\n\x06\x64\x65lete\x18\x06 \x01(\x08\x12*\n\x06vector\x18\x07 \x01(\x0b\x32\x1a.replication.VersionVector\"\xdb\x01\n\x0c\x46\x65tchRequest\x12*\n\x06vector\x18\x01 \x01(\x0b\x32\x1a.replication.VersionVector\x12#\n\x03ops\x18\x02 \x03(\x0b\x32\x16.replication.Operation\x12\x44\n\x0esegment_hashes\x18\x03 \x03(\x0b\x32,.replication.FetchRequest.SegmentHashesEntry\x1a\x34\n\x12SegmentHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xb1\x01\n\rFetchResponse\x12#\n\x03ops\x18\x01 \x03(\x0b\x32\x16.replication.Operation\x12\x45\n\x0esegment_hashes\x18\x02 \x03(\x0b\x32-.replication.FetchResponse.SegmentHashesEntry\x1a\x34\n\x12SegmentHashesEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x32\xf5\x01\n\x07Replica\x12\x30\n\x03Put\x12\x15.replication.KeyValue\x1a\x12.replication.Empty\x12\x35\n\x06\x44\x65lete\x12\x17.replication.KeyRequest\x1a\x12.replication.Empty\x12:\n\x03Get\x12\x17.replication.KeyRequest\x1a\x1a.replication.ValueResponse\x12\x45\n\x0c\x46\x65tchUpdates\x12\x19.replication.FetchRequest\x1a\x1a.replication.FetchResponse2F\n\x10HeartbeatService\x12\x32\n\x04Ping\x12\x16.replication.Heartbeat\x1a\x12.replication.Emptyb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -37,32 +37,32 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_options = b'8\001'
   _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._loaded_options = None
   _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_options = b'8\001'
-  _globals['_KEYREQUEST']._serialized_start=34
-  _globals['_KEYREQUEST']._serialized_end=154
-  _globals['_KEYVALUE']._serialized_start=157
-  _globals['_KEYVALUE']._serialized_end=290
-  _globals['_VALUERESPONSE']._serialized_start=292
-  _globals['_VALUERESPONSE']._serialized_end=385
-  _globals['_EMPTY']._serialized_start=387
-  _globals['_EMPTY']._serialized_end=394
-  _globals['_HEARTBEAT']._serialized_start=396
-  _globals['_HEARTBEAT']._serialized_end=424
-  _globals['_VERSIONVECTOR']._serialized_start=426
-  _globals['_VERSIONVECTOR']._serialized_end=541
-  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_start=497
-  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_end=541
-  _globals['_OPERATION']._serialized_start=544
-  _globals['_OPERATION']._serialized_end=694
-  _globals['_FETCHREQUEST']._serialized_start=697
-  _globals['_FETCHREQUEST']._serialized_end=916
-  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_start=864
-  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_end=916
-  _globals['_FETCHRESPONSE']._serialized_start=919
-  _globals['_FETCHRESPONSE']._serialized_end=1096
-  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_start=864
-  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_end=916
-  _globals['_REPLICA']._serialized_start=1099
-  _globals['_REPLICA']._serialized_end=1344
-  _globals['_HEARTBEATSERVICE']._serialized_start=1346
-  _globals['_HEARTBEATSERVICE']._serialized_end=1416
+  _globals['_KEYREQUEST']._serialized_start=35
+  _globals['_KEYREQUEST']._serialized_end=175
+  _globals['_KEYVALUE']._serialized_start=178
+  _globals['_KEYVALUE']._serialized_end=331
+  _globals['_VALUERESPONSE']._serialized_start=333
+  _globals['_VALUERESPONSE']._serialized_end=426
+  _globals['_EMPTY']._serialized_start=428
+  _globals['_EMPTY']._serialized_end=435
+  _globals['_HEARTBEAT']._serialized_start=437
+  _globals['_HEARTBEAT']._serialized_end=465
+  _globals['_VERSIONVECTOR']._serialized_start=467
+  _globals['_VERSIONVECTOR']._serialized_end=582
+  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_start=538
+  _globals['_VERSIONVECTOR_ITEMSENTRY']._serialized_end=582
+  _globals['_OPERATION']._serialized_start=585
+  _globals['_OPERATION']._serialized_end=735
+  _globals['_FETCHREQUEST']._serialized_start=738
+  _globals['_FETCHREQUEST']._serialized_end=957
+  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_start=905
+  _globals['_FETCHREQUEST_SEGMENTHASHESENTRY']._serialized_end=957
+  _globals['_FETCHRESPONSE']._serialized_start=960
+  _globals['_FETCHRESPONSE']._serialized_end=1137
+  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_start=905
+  _globals['_FETCHRESPONSE_SEGMENTHASHESENTRY']._serialized_end=957
+  _globals['_REPLICA']._serialized_start=1140
+  _globals['_REPLICA']._serialized_end=1385
+  _globals['_HEARTBEATSERVICE']._serialized_start=1387
+  _globals['_HEARTBEATSERVICE']._serialized_end=1457
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
## Summary
- extend gRPC messages with `hinted_for`
- regenerate protobuf bindings
- handle hinted handoff in `ReplicaService`
- update client helpers and replication logic for sloppy quorum

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d86133d688331b3b81ffc76f4cb43