### PR TITLE
Implement heartbeat-aware read quorum

### DIFF
--- a/replica/client.py
+++ b/replica/client.py
@@ -63,7 +63,8 @@ class GRPCReplicaClient:
         request = replication_pb2.KeyRequest(key=key, timestamp=0, node_id="")
         response = self.stub.Get(request)
         value = response.value if response.value else None
-        return value, response.timestamp
+        vector = dict(response.vector.items)
+        return value, response.timestamp, vector
 
     def fetch_updates(self, last_seen: dict, ops=None, segment_hashes=None):
         """Fetch updates from peer optionally sending our pending ops and hashes."""

--- a/tests/test_replication_factor.py
+++ b/tests/test_replication_factor.py
@@ -20,7 +20,7 @@ class ReplicationFactorThreeTest(unittest.TestCase):
                 expected_nodes = set(cluster.ring.get_preference_list(key, 3))
                 found_nodes = set()
                 for node in cluster.nodes:
-                    val, _ = node.client.get(key)
+                    val, _, _ = node.client.get(key)
                     if val == "v1":
                         found_nodes.add(node.node_id)
                 self.assertEqual(found_nodes, expected_nodes)


### PR DESCRIPTION
## Summary
- return version vector from `GRPCReplicaClient.get`
- use heartbeat checks and vectors during `NodeCluster.get`
- adjust cluster node helper and tests for new return signature

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d8ce10ae4833190093150aae68b9e