### PR TITLE
Update docs for grpc setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ sequenceDiagram
 
 ## Executando
 
-1. Instale as dependências
+1. Instale as dependências (incluindo `grpcio` utilizado na comunicação gRPC)
    ```bash
    pip install -r requirements.txt
    ```
@@ -312,7 +312,8 @@ with TemporaryDirectory() as dir_a, TemporaryDirectory() as dir_b:
 
 ## Testes
 
-Execute a bateria de testes para validar o sistema:
+Execute a bateria de testes para validar o sistema (as dependências `grpcio` e
+`grpcio-tools` do `requirements.txt` são necessárias):
 ```bash
 python -m unittest discover -s tests -v
 ```


### PR DESCRIPTION
## Summary
- note that requirements install grpcio
- mention grpcio/grpcio-tools are needed for the tests

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_684da362a55c833190e0ca2dca94a69c