### PR TITLE
Update NodeCluster to use get_node_for_key

### DIFF
--- a/replication.py
+++ b/replication.py
@@ -169,14 +169,24 @@ class NodeCluster:
         return self.nodes_by_id[node_id]
 
     def put(self, node_index: int, key: str, value: str):
-        node = self._coordinator(key)
+        if self.key_ranges is not None:
+            node = self.get_node_for_key(key)
+        else:
+            node = self._coordinator(key)
         node.put(key, value)
 
     def delete(self, node_index: int, key: str):
-        node = self._coordinator(key)
+        if self.key_ranges is not None:
+            node = self.get_node_for_key(key)
+        else:
+            node = self._coordinator(key)
         node.delete(key)
 
     def get(self, node_index: int, key: str, *, merge: bool = True):
+        if self.key_ranges is not None:
+            node = self.get_node_for_key(key)
+            recs = node.client.get(key)
+            return recs[0][0] if recs else None
         if self.ring is None:
             node = self._coordinator(key)
             recs = node.client.get(key)


### PR DESCRIPTION
## Summary
- use `get_node_for_key` in `NodeCluster.put`, `get`, and `delete`
- preserve ring-based routing when `key_ranges` is unset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503f93553883319538c5e895b2210f