### PR TITLE
Adjust NodeCluster for range partitions

### DIFF
--- a/replication.py
+++ b/replication.py
@@ -94,6 +94,12 @@ class NodeCluster:
                     ("localhost", base_port + j, f"node_{j}")
                     for j in topology.get(i, [])
                 ]
+
+            rf = self.replication_factor
+            if key_ranges is not None:
+                peers_i = []
+                rf = 1
+
             p = multiprocessing.Process(
                 target=run_server,
                 args=(
@@ -103,7 +109,7 @@ class NodeCluster:
                     node_id,
                     peers_i,
                     self.ring,
-                    self.replication_factor,
+                    rf,
                     self.write_quorum,
                     self.read_quorum,
                 ),


### PR DESCRIPTION
## Summary
- avoid cross-node replication when key ranges are provided by passing no peers and replication_factor=1
- keep behaviour unchanged for unpartitioned clusters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685041d67cf083318586aaa846454b7e