### PR TITLE
Add composite key parameters for Driver & NodeCluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ from driver import Driver
 
 cluster = NodeCluster(num_nodes=2)
 driver = Driver(cluster)
-driver.put("alice", "k", "v")
-value = driver.get("alice", "k")
+driver.put("alice", "k", "1", "v")
+value = driver.get("alice", "k", "1")
 cluster.shutdown()
 ```
 

--- a/main.py
+++ b/main.py
@@ -2,9 +2,9 @@ from replication import NodeCluster
 def main():
     """Exemplo simples de uso do banco de dados replicado."""
     cluster = NodeCluster(base_path="example_cluster", num_nodes=3)
-    cluster.put(0, "exemplo:chave", "valor")
-    print("Valor no nó 0:", cluster.get(0, "exemplo:chave"))
-    print("Valor no nó 1:", cluster.get(1, "exemplo:chave"))
+    cluster.put(0, "exemplo", "chave", "valor")
+    print("Valor no nó 0:", cluster.get(0, "exemplo", "chave"))
+    print("Valor no nó 1:", cluster.get(1, "exemplo", "chave"))
     cluster.shutdown()
 
 

--- a/replication.py
+++ b/replication.py
@@ -199,10 +199,17 @@ class NodeCluster:
         self,
         node_index: int,
         partition_key: str,
-        value: str,
-        *,
-        clustering_key: str | None = None,
+        clustering_key: str,
+        value: str | None = None,
     ):
+        """Insert ``value`` using ``partition_key`` and ``clustering_key``.
+
+        For backwards compatibility ``clustering_key`` may actually be the
+        ``value`` when only a single key component is provided.
+        """
+        if value is None:
+            value = clustering_key
+            clustering_key = None
         composed_key = compose_key(partition_key, clustering_key)
         node = self._coordinator(partition_key, clustering_key)
         node.put(composed_key, value)
@@ -211,9 +218,13 @@ class NodeCluster:
         self,
         node_index: int,
         partition_key: str,
-        *,
         clustering_key: str | None = None,
     ):
+        """Delete key identified by ``partition_key`` and ``clustering_key``.
+
+        Backwards compatible with calls that omit ``clustering_key`` and pass a
+        single combined key as ``partition_key``.
+        """
         composed_key = compose_key(partition_key, clustering_key)
         node = self._coordinator(partition_key, clustering_key)
         node.delete(composed_key)
@@ -222,10 +233,15 @@ class NodeCluster:
         self,
         node_index: int,
         partition_key: str,
-        *,
         clustering_key: str | None = None,
+        *,
         merge: bool = True,
     ):
+        """Retrieve the value stored under ``partition_key`` and ``clustering_key``.
+
+        The optional ``clustering_key`` keeps compatibility with the previous
+        API where a single key string was used.
+        """
         composed_key = compose_key(partition_key, clustering_key)
         if self.partition_strategy == "hash":
             node = self._coordinator(partition_key, clustering_key)


### PR DESCRIPTION
## Summary
- require partition and clustering keys in `Driver` and `NodeCluster`
- keep old single-key usage for backward compatibility
- update example and README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68506ab8083c83318c35edcbd876351a