### PR TITLE
Support pre-sharding with more partitions than nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,8 @@ Cada tupla define o início e o fim (exclusivo) de uma faixa. No exemplo
 acima, o primeiro nó cuida das chaves de `'a'` até `'m'` e o segundo das
 demais. Por enquanto cada partição possui apenas uma réplica, mas o
 projeto prevê suportar múltiplas cópias e realocação dinâmica das
-faixas em versões futuras.
+faixas em versões futuras. É possível definir mais faixas do que nós; elas são
+atribuídas em esquema *round-robin* para balancear a carga.
 
 ## Particionamento por Hash de Chave
 
@@ -376,6 +377,15 @@ from replication import NodeCluster
 cluster = NodeCluster('/tmp/hash_cluster', num_nodes=3,
                       partition_strategy='hash',
                       replication_factor=1)
+```
+
+Para pré-criar um número maior de partições do que nós, defina
+`num_partitions` explicitamente. As partições extras serão distribuídas em
+round-robin entre os nós:
+
+```python
+cluster = NodeCluster('/tmp/pre', num_nodes=2,
+                      partition_strategy='hash', num_partitions=4)
 ```
 
 Essa estratégia tende a balancear bem os dados entre os nós, mas consultas por

--- a/tests/test_pre_shard_hash.py
+++ b/tests/test_pre_shard_hash.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class PreShardHashTest(unittest.TestCase):
+    def test_more_partitions_than_nodes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                replication_factor=1,
+                partition_strategy="hash",
+                num_partitions=4,
+            )
+            try:
+                keys = {}
+                i = 0
+                while len(keys) < cluster.num_partitions:
+                    k = f"k{i}"
+                    pid = cluster.get_partition_id(k)
+                    if pid not in keys:
+                        keys[pid] = k
+                    i += 1
+                for pid, k in keys.items():
+                    cluster.put(0, k, f"v{pid}")
+                time.sleep(0.2)
+                for pid, k in keys.items():
+                    node_index = pid % len(cluster.nodes)
+                    recs = cluster.nodes[node_index].client.get(k)
+                    self.assertTrue(recs)
+                    self.assertEqual(recs[0][0], f"v{pid}")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pre_shard_range.py
+++ b/tests/test_pre_shard_range.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class PreShardRangeTest(unittest.TestCase):
+    def test_more_ranges_than_nodes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ranges = [("a", "d"), ("d", "g"), ("g", "j"), ("j", "m")]
+            cluster = NodeCluster(base_path=tmpdir, num_nodes=2, key_ranges=ranges)
+            try:
+                keys = ["b", "e", "h", "k"]
+                for i, k in enumerate(keys):
+                    cluster.put(0, k, f"v{i}")
+                time.sleep(0.2)
+                for i, k in enumerate(keys):
+                    node_index = i % len(cluster.nodes)
+                    recs = cluster.nodes[node_index].client.get(k)
+                    self.assertTrue(recs)
+                    self.assertEqual(recs[0][0], f"v{i}")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `NodeCluster` to specify `num_partitions`
- distribute manual key ranges in round-robin
- document `num_partitions` and range distribution in README
- add tests covering pre-sharding for hash and range strategies

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_pre_shard_hash.py::PreShardHashTest::test_more_partitions_than_nodes -q`
- `pytest tests/test_pre_shard_range.py::PreShardRangeTest::test_more_ranges_than_nodes -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850742089148331938c0180183230e8