### PR TITLE
Implement salted key support

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,24 @@ Essa estratégia tende a balancear bem os dados entre os nós, mas consultas por
 faixa de valores precisam acessar várias partições para coletar todos os
 resultados.
 
+## Random Prefixing/Salting
+
+Para evitar hotspots em chaves muito acessadas é possível habilitar um
+*salting* que adiciona um prefixo aleatório antes da chave de partição. As
+escritas ficam distribuídas em diferentes partições e a leitura consulta todas
+as variações retornando o valor mais recente.
+
+```python
+from replication import NodeCluster
+
+cluster = NodeCluster('/tmp/hash_cluster', num_nodes=3,
+                      partition_strategy='hash')
+cluster.enable_salt('hotkey', buckets=4)
+
+cluster.put(0, 'hotkey', 'value')
+print(cluster.get(1, 'hotkey'))
+```
+
 ## Testes
 
 Execute a bateria de testes para validar o sistema. Instale antes as

--- a/tests/test_salting.py
+++ b/tests/test_salting.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class SaltingTest(unittest.TestCase):
+    def test_random_prefix_distribution_and_read(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=3,
+                replication_factor=1,
+                partition_strategy="hash",
+            )
+            cluster.enable_salt("hot", buckets=3)
+            try:
+                for i in range(20):
+                    cluster.put(0, "hot", f"v{i}")
+                time.sleep(0.5)
+
+                used_partitions = set()
+                for prefix in range(3):
+                    salted = f"{prefix}#hot"
+                    pid = cluster.get_partition_id(salted)
+                    node = cluster.nodes[pid % len(cluster.nodes)]
+                    if node.client.get(salted):
+                        used_partitions.add(pid)
+                self.assertGreater(len(used_partitions), 1)
+
+                self.assertEqual(cluster.get(1, "hot"), "v19")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add optional salting for hot partition keys in `NodeCluster`
- update cluster `put` and `get` to handle salted keys
- document random prefixing in README
- test salting logic

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6850760f20108331942c39a7c81cbd73