### PR TITLE
Add partition split functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,20 @@ cluster.put(0, 'hotkey', 'value')
 print(cluster.get(1, 'hotkey'))
 ```
 
+## Divisão de Partições
+
+Quando uma faixa se torna muito movimentada é possível dividi-la manualmente
+chamando `split_partition(pid, split_key=None)`. O método recebe o índice da
+partição atual e opcionalmente a chave que servirá de limite entre as novas
+faixas. Sem parâmetro, um ponto médio aproximado é utilizado.
+
+```python
+cluster.split_partition(0, 'g')  # cria ['a','g') e ['g','m')
+```
+
+A divisão apenas redireciona novas escritas; os dados existentes permanecem em
+sua localização original.
+
 ## Testes
 
 Execute a bateria de testes para validar o sistema. Instale antes as

--- a/tests/test_split_on_write.py
+++ b/tests/test_split_on_write.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class SplitOnWriteTest(unittest.TestCase):
+    def test_split_partition_routes_new_data(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ranges = [("a", "m"), ("m", "z")]
+            cluster = NodeCluster(base_path=tmpdir, num_nodes=2, key_ranges=ranges)
+            try:
+                cluster.split_partition(0, "g")
+                cluster.put(0, "ga", "val")
+                time.sleep(0.2)
+                self.assertEqual(cluster.num_partitions, 3)
+                node_new = cluster.partitions[1][1]
+                node_old = cluster.partitions[0][1]
+                self.assertTrue(node_new.client.get("ga"))
+                self.assertFalse(node_old.client.get("ga"))
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track operation counts per partition
- implement `split_partition` to divide existing range partitions
- add unit test for manual partition split and routing
- document how to split partitions in the README

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6850797883808331bae5bc0780a5998e