### PR TITLE
Implement request forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,15 @@ node = cluster.add_node()
 cluster.remove_node(node.node_id)
 ```
 
+## Nó Coordenador (forwarding)
+
+Um cliente pode contatar qualquer nó do cluster. Se o servidor que recebeu a
+requisição não for o responsável pela partição da chave, ele pode encaminhar a
+operação para o dono correto usando o hash ring (ou tabela de faixas) e retornar
+o resultado. Essa capacidade é opcional e habilitada ao inicializar o
+`NodeCluster` com `enable_forwarding=True`. Assim a aplicação não precisa
+conhecer previamente qual nó detém a partição.
+
 ## Testes
 
 Execute a bateria de testes para validar o sistema. Instale antes as

--- a/replication.py
+++ b/replication.py
@@ -66,6 +66,7 @@ class NodeCluster:
         num_partitions: int | None = None,
         partitions_per_node: int = 1,
         max_transfer_rate: int | None = None,
+        enable_forwarding: bool = False,
     ):
         self.base_path = base_path
         if os.path.exists(base_path):
@@ -88,6 +89,7 @@ class NodeCluster:
             raise ValueError("invalid partition_strategy")
         self.partitions_per_node = max(1, int(partitions_per_node))
         self.max_transfer_rate = max_transfer_rate
+        self.enable_forwarding = enable_forwarding
         self.key_ranges = None
         self.partitions: list[tuple[tuple, ClusterNode]] = []
         self.ring = None if key_ranges else ConsistentHashRing()
@@ -137,7 +139,10 @@ class NodeCluster:
                     self.write_quorum,
                     self.read_quorum,
                 ),
-                kwargs={"consistency_mode": self.consistency_mode},
+                kwargs={
+                    "consistency_mode": self.consistency_mode,
+                    "enable_forwarding": self.enable_forwarding,
+                },
                 daemon=True,
             )
             p.start()
@@ -693,7 +698,10 @@ class NodeCluster:
                 self.write_quorum,
                 self.read_quorum,
             ),
-            kwargs={"consistency_mode": self.consistency_mode},
+            kwargs={
+                "consistency_mode": self.consistency_mode,
+                "enable_forwarding": self.enable_forwarding,
+            },
             daemon=True,
         )
         p.start()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import tempfile
+import time
+import random
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class CoordinatorForwardingTest(unittest.TestCase):
+    def test_forwarding_put_get_delete(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=3,
+                replication_factor=1,
+                partition_strategy="hash",
+                enable_forwarding=True,
+            )
+            try:
+                key = "route:key"
+                owner_id = cluster.ring.get_preference_list(key, 1)[0]
+                wrong_node = random.choice(
+                    [n for n in cluster.nodes if n.node_id != owner_id]
+                )
+
+                # PUT via wrong node
+                wrong_node.client.put(key, "v1")
+                time.sleep(0.5)
+
+                recs_owner = cluster.nodes_by_id[owner_id].client.get(key)
+                self.assertTrue(recs_owner and recs_owner[0][0] == "v1")
+
+                # GET via wrong node should be forwarded
+                recs_wrong = wrong_node.client.get(key)
+                self.assertTrue(recs_wrong and recs_wrong[0][0] == "v1")
+
+                # DELETE via wrong node
+                wrong_node.client.delete(key)
+                time.sleep(0.5)
+                self.assertFalse(cluster.nodes_by_id[owner_id].client.get(key))
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_salting.py
+++ b/tests/test_salting.py
@@ -22,6 +22,7 @@ class SaltingTest(unittest.TestCase):
             try:
                 for i in range(20):
                     cluster.put(0, "hot", f"v{i}")
+                    time.sleep(0.001)
                 time.sleep(0.5)
 
                 used_partitions = set()


### PR DESCRIPTION
## Summary
- add optional request forwarding for `ReplicaService`
- wire forwarding via `NodeCluster` initialization
- document forwarding setting
- test coordinator forwarding behaviour
- stabilize salting test timestamps

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68517f4e4bc08331972f45a581bc2ee8