### PR TITLE
Add topology-aware driver with partition cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Se um nó ficar offline, ele pode recuperar as mudanças perdidas ao reprovar o 
 - **Compactação** – remove registros obsoletos ao mesclar SSTables.
 - **Lamport Clock** – contador lógico usado para ordenar operações entre nós.
 - **Replicação multi-líder** – qualquer nó pode aceitar escritas e replicá-las para todos os outros de forma assíncrona.
-- **Driver opcional** – encaminha requisições para garantir "read your own writes".
+- **Driver opcional** – cliente consciente da topologia que mantém cache de partições.
 - **Log de replicação** – armazena operações geradas localmente até que todos os pares confirmem o recebimento.
 - **Vetor de versões** – cada nó mantém `last_seen` (origem → último contador) para aplicar cada operação exatamente uma vez.
 - **Heartbeat** – serviço `Ping` que monitora a disponibilidade dos peers.
@@ -139,6 +139,13 @@ driver.put("alice", "k", "1", "v")
 value = driver.get("alice", "k", "1")
 cluster.shutdown()
 ```
+
+### Cliente Consciente da Topologia
+
+O driver mantém um cache local do mapeamento de partições obtido com
+`get_partition_map()`. As requisições são enviadas diretamente ao nó
+responsável. Caso o nó retorne o erro `NotOwner` (por exemplo após uma
+migração de partição), o driver atualiza o cache e repete a operação.
 
 ## Topologia de replicação
 

--- a/replication.py
+++ b/replication.py
@@ -223,6 +223,22 @@ class NodeCluster:
         self.num_partitions = len(self.ring._ring)
         self.partition_ops = [0] * self.num_partitions
 
+    def get_partition_map(self) -> dict[int, str]:
+        """Return mapping from partition id to owning node id."""
+        mapping: dict[int, str] = {}
+        if self.ring is not None and self.ring._ring:
+            for i, (_, nid) in enumerate(self.ring._ring):
+                mapping[i] = nid
+            return mapping
+        if self.key_ranges is not None:
+            for i, (_, node) in enumerate(self.partitions):
+                mapping[i] = node.node_id
+            return mapping
+        for pid in range(self.num_partitions):
+            node = self.nodes[pid % len(self.nodes)]
+            mapping[pid] = node.node_id
+        return mapping
+
     def get_partition_id(
         self, partition_key: str, clustering_key: str | None = None
     ) -> int:

--- a/tests/test_smart_driver.py
+++ b/tests/test_smart_driver.py
@@ -1,0 +1,75 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+from driver import Driver
+from partitioning import compose_key
+
+
+class SmartDriverTest(unittest.TestCase):
+    def test_driver_routes_to_owner(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                replication_factor=1,
+                partition_strategy="hash",
+                enable_forwarding=False,
+            )
+            try:
+                driver = Driver(cluster)
+                key = "alpha"
+                pid = cluster.get_partition_id(key)
+                owner = cluster.get_partition_map()[pid]
+                driver.put("u", key, "v1")
+                time.sleep(0.5)
+                k = compose_key(key)
+                self.assertTrue(cluster.nodes_by_id[owner].client.get(k))
+                other = "node_1" if owner == "node_0" else "node_0"
+                try:
+                    self.assertFalse(cluster.nodes_by_id[other].client.get(k))
+                except Exception:
+                    pass
+            finally:
+                cluster.shutdown()
+
+    def test_driver_refresh_after_migration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                replication_factor=1,
+                partition_strategy="hash",
+                enable_forwarding=False,
+            )
+            try:
+                driver = Driver(cluster)
+                key = "beta"
+                pid = cluster.get_partition_id(key)
+                owner = cluster.get_partition_map()[pid]
+                other = "node_1" if owner == "node_0" else "node_0"
+
+                driver.put("u", key, "v1")
+                time.sleep(0.5)
+
+                # simulate stale cache
+                driver.partition_map[pid] = other
+
+                # driver will refresh after receiving NotOwner
+                driver.put("u", key, "v2")
+                time.sleep(0.5)
+
+                k = compose_key(key)
+                recs_new = cluster.nodes_by_id[owner].client.get(k)
+                self.assertTrue(recs_new and recs_new[0][0] == "v2")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `get_partition_map` to `NodeCluster`
- implement smart client behavior in `driver`
- return `NotOwner` error when an external client contacts a wrong node
- document topology aware driver in README
- add tests for the new driver cache behaviour

## Testing
- `pytest tests/test_smart_driver.py tests/test_replication.py::ReplicationManagerTest::test_basic_replication -q`

------
https://chatgpt.com/codex/tasks/task_e_6851953f7d88833183aef54e58d46350