### PR TITLE
Forwarding uses static partition map

### DIFF
--- a/tests/test_read_repair.py
+++ b/tests/test_read_repair.py
@@ -38,6 +38,7 @@ class ReadRepairTest(unittest.TestCase):
                         stale_id,
                         peers,
                         cluster.ring,
+                        cluster.partition_map,
                         cluster.replication_factor,
                         cluster.write_quorum,
                         cluster.read_quorum,

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -100,7 +100,18 @@ class ReplicationManagerTest(unittest.TestCase):
                 peers = [("localhost", 9000), ("localhost", 9001)]
                 p = multiprocessing.Process(
                     target=run_server,
-                    args=(db_path, "localhost", 9001, "node_1", peers),
+                    args=(
+                        db_path,
+                        "localhost",
+                        9001,
+                        "node_1",
+                        peers,
+                        cluster.ring,
+                        cluster.partition_map,
+                        cluster.replication_factor,
+                        cluster.write_quorum,
+                        cluster.read_quorum,
+                    ),
                     daemon=True,
                 )
                 p.start()
@@ -137,7 +148,18 @@ class ReplicationManagerTest(unittest.TestCase):
                 peers = [("localhost", 9000), ("localhost", 9001)]
                 p = multiprocessing.Process(
                     target=run_server,
-                    args=(db_path, "localhost", 9001, "node_1", peers),
+                    args=(
+                        db_path,
+                        "localhost",
+                        9001,
+                        "node_1",
+                        peers,
+                        cluster.ring,
+                        cluster.partition_map,
+                        cluster.replication_factor,
+                        cluster.write_quorum,
+                        cluster.read_quorum,
+                    ),
                     daemon=True,
                 )
                 p.start()
@@ -173,7 +195,18 @@ class ReplicationManagerTest(unittest.TestCase):
                 peers = [("localhost", 9000), ("localhost", 9001)]
                 p = multiprocessing.Process(
                     target=run_server,
-                    args=(db_path, "localhost", 9001, "node_1", peers),
+                    args=(
+                        db_path,
+                        "localhost",
+                        9001,
+                        "node_1",
+                        peers,
+                        cluster.ring,
+                        cluster.partition_map,
+                        cluster.replication_factor,
+                        cluster.write_quorum,
+                        cluster.read_quorum,
+                    ),
                     daemon=True,
                 )
                 p.start()

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -22,7 +22,8 @@ class CoordinatorForwardingTest(unittest.TestCase):
             )
             try:
                 key = "route:key"
-                owner_id = cluster.ring.get_preference_list(key, 1)[0]
+                pid = cluster.get_partition_id(key)
+                owner_id = cluster.get_partition_map()[pid]
                 wrong_node = random.choice(
                     [n for n in cluster.nodes if n.node_id != owner_id]
                 )

--- a/tests/test_sloppy_quorum.py
+++ b/tests/test_sloppy_quorum.py
@@ -54,6 +54,7 @@ class SloppyQuorumTest(unittest.TestCase):
                         offline_id,
                         peers,
                         cluster.ring,
+                        cluster.partition_map,
                         cluster.replication_factor,
                         cluster.write_quorum,
                         cluster.read_quorum,


### PR DESCRIPTION
## Summary
- give NodeServer knowledge of entire partition map on start
- store the map and expose method to update
- ReplicaService uses `self.partition_map` to find owners
- adapt NodeCluster to compute and pass map to run_server
- update tests that restart nodes to pass the map

## Testing
- `pytest -q tests/test_routing.py`
- `pytest -q tests/test_read_repair.py tests/test_sloppy_quorum.py tests/test_replication.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851e9585a048331acde96e3011051cf