### PR TITLE
Implement hotspot metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,24 @@ cluster.put(0, 'hotkey', 'value')
 print(cluster.get(1, 'hotkey'))
 ```
 
+## Métricas de Hotspots
+
+A classe `NodeCluster` mantém contadores de operações por partição
+(`partition_ops`) e de frequência de acesso por chave (`key_freq`).
+Chame `reset_metrics()` para zerar esses valores.
+
+Use `get_hot_partitions(threshold=2.0)` para listar as partições cuja
+contagem de operações ultrapassa `threshold` vezes a média. O método
+`get_hot_keys(top_n=5)` retorna as chaves mais acessadas.
+
+```python
+cluster.reset_metrics()
+for _ in range(10):
+    cluster.put(0, 'hot', 'x')
+print(cluster.get_hot_partitions())
+print(cluster.get_hot_keys())
+```
+
 ## Divisão de Partições
 
 Quando uma faixa se torna muito movimentada é possível dividi-la manualmente

--- a/tests/test_hotspots.py
+++ b/tests/test_hotspots.py
@@ -1,0 +1,64 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+from partitioning import compose_key
+
+class HotspotMetricsTest(unittest.TestCase):
+    def test_metrics_increment(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                replication_factor=1,
+                partition_strategy="hash",
+                num_partitions=2,
+            )
+            try:
+                cluster.reset_metrics()
+                cluster.put(0, "k", "c", "v")
+                cluster.get(1, "k", "c")
+                cluster.delete(0, "k", "c")
+
+                comp = compose_key("k", "c")
+                pid = cluster.get_partition_id("k", "c")
+                self.assertEqual(cluster.partition_ops[pid], 3)
+                self.assertEqual(cluster.key_freq.get(comp), 3)
+            finally:
+                cluster.shutdown()
+
+    def test_hot_partition_and_key_detection(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                replication_factor=1,
+                partition_strategy="hash",
+                num_partitions=4,
+            )
+            try:
+                cluster.reset_metrics()
+                # heavy load on one key
+                for _ in range(10):
+                    cluster.put(0, "hot", "x", "v")
+                    cluster.get(1, "hot", "x")
+                # small load on another key
+                cluster.put(0, "cold", "y", "z")
+                cluster.get(1, "cold", "y")
+
+                hot_pid = cluster.get_partition_id("hot", "x")
+                hot_parts = cluster.get_hot_partitions()
+                self.assertIn(hot_pid, hot_parts)
+
+                hot_key = compose_key("hot", "x")
+                self.assertEqual(cluster.get_hot_keys(1)[0], hot_key)
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track key frequencies and partition operations
- expose helpers to detect hot partitions and keys
- unit tests for new hotspot metrics
- document hotspot detection usage

## Testing
- `pip install -r requirements.txt`
- `python -m unittest tests/test_hotspots.py -v`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68520836ed688331991a3e499f184bf0