### PR TITLE
Update routing docs for partition map refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,19 @@ driver.put('u', 'key', 'valor')
 print(driver.get('u', 'key'))
 ```
 
+### Atualização de mapeamento
+
+Caso uma partição seja dividida ou o cluster passe por um rebalanceamento,
+execute `cluster.update_partition_map()` para distribuir o novo mapa a todas as
+réplicas pelo RPC `UpdatePartitionMap`. O método retorna o dicionário de
+partições, permitindo que drivers ou roteadores atualizem seu cache:
+
+```python
+cluster.split_partition(0, "g")
+mapping = cluster.update_partition_map()
+driver.update_partition_map(mapping)  # ou router.update_partition_map(mapping)
+```
+
 ### Testes do estágio
 
 Execute apenas os testes de roteamento e do driver:


### PR DESCRIPTION
## Summary
- document `NodeCluster.update_partition_map` under the routing section
- explain new `UpdatePartitionMap` RPC
- show how drivers or routers refresh cached mappings

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v` *(fails: test_matching_segment_hashes_skip_transfer)*

------
https://chatgpt.com/codex/tasks/task_e_685216468284833197856061e15b6326