### PR TITLE
Implement dynamic hot key salting

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,18 @@ cluster.put(0, 'hotkey', 'value')
 print(cluster.get(1, 'hotkey'))
 ```
 
+### Salting Dinâmico de Hot-Keys
+
+Em cenários nos quais uma chave torna-se "quente" apenas após certo tempo,
+é possível ativar o salting de forma dinâmica. O método
+`mark_hot_key(key, buckets, migrate=True)` passa a distribuir novas escritas
+entre ``buckets`` prefixos e pode opcionalmente migrar o valor atual para
+cada variação.
+
+```python
+cluster.mark_hot_key('hotkey', buckets=4, migrate=True)
+```
+
 ## Métricas de Hotspots
 
 A classe `NodeCluster` mantém contadores de operações por partição

--- a/replication.py
+++ b/replication.py
@@ -202,6 +202,17 @@ class NodeCluster:
             raise ValueError("buckets must be >= 1")
         self.salted_keys[str(key)] = int(buckets)
 
+    def mark_hot_key(self, key: str, buckets: int, migrate: bool = False) -> None:
+        """Start salting ``key`` and optionally migrate existing data."""
+        self.enable_salt(key, buckets)
+        if migrate:
+            value = self.get(0, key, ignore_salt=True)
+            if value is None:
+                return
+            for i in range(buckets):
+                salted = f"{i}#{key}"
+                self.put(0, salted, value)
+
     def set_max_transfer_rate(self, rate: int | None) -> None:
         """Configure maximum transfer rate in bytes/second."""
         self.max_transfer_rate = rate

--- a/tests/test_mark_hot_key.py
+++ b/tests/test_mark_hot_key.py
@@ -1,0 +1,57 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class MarkHotKeyTest(unittest.TestCase):
+    def test_mark_without_migration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=3,
+                replication_factor=1,
+                partition_strategy="hash",
+            )
+            try:
+                cluster.put(0, "hk", "v0")
+                cluster.mark_hot_key("hk", buckets=2, migrate=False)
+                # old value should be accessible only ignoring salt
+                self.assertIsNone(cluster.get(1, "hk"))
+                self.assertEqual(cluster.get(1, "hk", ignore_salt=True), "v0")
+
+                cluster.put(0, "hk", "v1")
+                self.assertEqual(cluster.get(1, "hk"), "v1")
+            finally:
+                cluster.shutdown()
+
+    def test_mark_with_migration(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=3,
+                replication_factor=1,
+                partition_strategy="hash",
+            )
+            try:
+                cluster.put(0, "hot", "orig")
+                time.sleep(0.1)
+                cluster.mark_hot_key("hot", buckets=3, migrate=True)
+                self.assertEqual(cluster.get(1, "hot"), "orig")
+                for i in range(3):
+                    salted = f"{i}#hot"
+                    pid = cluster.get_partition_id(salted)
+                    node = cluster.nodes[pid % len(cluster.nodes)]
+                    recs = node.client.get(salted)
+                    self.assertTrue(recs and recs[0][0] == "orig")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow promoting existing keys to salted hot keys
- document how to mark hot keys dynamically
- add unit tests for hot key promotion

## Testing
- `pytest tests/test_mark_hot_key.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68521a2b2d2083318f6d561e65680fc2