### PR TITLE
Add hot key detection

### DIFF
--- a/replication.py
+++ b/replication.py
@@ -213,6 +213,21 @@ class NodeCluster:
                 salted = f"{i}#{key}"
                 self.put(0, salted, value)
 
+    def check_hot_keys(self, threshold: int, buckets: int) -> None:
+        """Mark keys with high access frequency as hot.
+
+        Iterates over ``key_freq`` and calls :py:meth:`mark_hot_key` for any
+        key whose counter exceeds ``threshold`` and isn't already salted.
+        The frequency counter for a key is reset once salting is enabled.
+        """
+        for comp_key, count in list(self.key_freq.items()):
+            if count >= threshold:
+                pk, _ = self._split_key_components(comp_key)
+                if pk in self.salted_keys:
+                    continue
+                self.mark_hot_key(pk, buckets)
+                self.key_freq[comp_key] = 0
+
     def set_max_transfer_rate(self, rate: int | None) -> None:
         """Configure maximum transfer rate in bytes/second."""
         self.max_transfer_rate = rate

--- a/tests/test_check_hot_keys.py
+++ b/tests/test_check_hot_keys.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class CheckHotKeysTest(unittest.TestCase):
+    def test_auto_mark_after_threshold(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=3,
+                replication_factor=1,
+                partition_strategy="hash",
+            )
+            try:
+                for i in range(4):
+                    cluster.put(0, "thk", f"v{i}")
+                cluster.check_hot_keys(threshold=5, buckets=2)
+                self.assertNotIn("thk", cluster.salted_keys)
+
+                cluster.put(0, "thk", "v4")
+                cluster.check_hot_keys(threshold=5, buckets=2)
+                self.assertIn("thk", cluster.salted_keys)
+
+                cluster.put(0, "thk", "v5")
+                self.assertEqual(cluster.get(1, "thk"), "v5")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support detecting hot keys dynamically via `check_hot_keys`
- test that salting is triggered once frequency threshold is reached

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685239e35f0c8331b1f9a4b3309b8596