### PR TITLE
Add optional LRU cache for NodeServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Se um nó ficar offline, ele pode recuperar as mudanças perdidas ao reprovar o 
 - **Lamport Clock** – contador lógico usado para ordenar operações entre nós.
 - **Replicação multi-líder** – qualquer nó pode aceitar escritas e replicá-las para todos os outros de forma assíncrona.
 - **Driver opcional** – cliente consciente da topologia que mantém cache de partições.
+- **Cache LRU opcional** – cada nó pode armazenar leituras recentes definindo `cache_size` no `NodeServer`.
 - **Log de replicação** – armazena operações geradas localmente até que todos os pares confirmem o recebimento.
 - **Vetor de versões** – cada nó mantém `last_seen` (origem → último contador) para aplicar cada operação exatamente uma vez.
 - **Heartbeat** – serviço `Ping` que monitora a disponibilidade dos peers.
@@ -598,6 +599,12 @@ cluster.split_partition(0, "g")
 mapping = cluster.update_partition_map()
 driver.update_partition_map(mapping)  # ou router.update_partition_map(mapping)
 ```
+
+### Cache de leituras
+
+Defina `cache_size` ao criar cada `NodeServer` para habilitar um cache LRU de leituras.
+As entradas são consultadas em `Get` e invalidadas em `Put` ou `Delete`. Utilize
+`cache_size=0` (padrão) para desativar o recurso.
 
 ### Testes do estágio
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replica.grpc_server import NodeServer, ReplicaService
+from replica import replication_pb2
+
+
+class NodeCacheTest(unittest.TestCase):
+    def test_cache_updates_after_put(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, cache_size=2)
+            service = ReplicaService(node)
+
+            req1 = replication_pb2.KeyValue(key="k", value="v1", timestamp=1)
+            service.Put(req1, None)
+            resp1 = service.Get(replication_pb2.KeyRequest(key="k", timestamp=0), None)
+            self.assertEqual(resp1.values[0].value, "v1")
+
+            req2 = replication_pb2.KeyValue(key="k", value="v2", timestamp=2)
+            service.Put(req2, None)
+            resp2 = service.Get(replication_pb2.KeyRequest(key="k", timestamp=0), None)
+            self.assertEqual(resp2.values[0].value, "v2")
+            node.db.close()
+
+    def test_cache_invalidated_on_delete(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, cache_size=2)
+            service = ReplicaService(node)
+
+            service.Put(replication_pb2.KeyValue(key="k", value="v1", timestamp=1), None)
+            service.Get(replication_pb2.KeyRequest(key="k", timestamp=0), None)
+            service.Delete(replication_pb2.KeyRequest(key="k", timestamp=2), None)
+            resp = service.Get(replication_pb2.KeyRequest(key="k", timestamp=0), None)
+            self.assertEqual(len(resp.values), 0)
+            node.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `cache_size` parameter to `NodeServer`
- implement LRU cache helpers and use them in ReplicaService
- invalidate cache after writes
- document caching in README
- add unit tests for cache functionality

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6852dcdf900883319685bbc280f98825