### PR TITLE
Add partition stats helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,9 @@ cluster.mark_hot_key('hotkey', buckets=4, migrate=True)
 
 A classe `NodeCluster` mantém contadores de operações por partição
 (`partition_ops`) e de frequência de acesso por chave (`key_freq`).
-Chame `reset_metrics()` para zerar esses valores.
+Chame `reset_metrics()` para zerar esses valores. Utilize
+`get_partition_stats()` para obter o número de operações executadas em cada
+partição.
 
 Use `get_hot_partitions(threshold=2.0)` para listar as partições cuja
 contagem de operações ultrapassa `threshold` vezes a média. O método

--- a/replication.py
+++ b/replication.py
@@ -249,6 +249,10 @@ class NodeCluster:
         """Return most frequently accessed keys."""
         return [k for k, _ in sorted(self.key_freq.items(), key=lambda kv: kv[1], reverse=True)[:top_n]]
 
+    def get_partition_stats(self) -> dict[int, int]:
+        """Return a mapping pid -> operation count."""
+        return {i: cnt for i, cnt in enumerate(self.partition_ops)}
+
     def get_node_for_key(
         self, partition_key: str, clustering_key: str | None = None
     ) -> ClusterNode:


### PR DESCRIPTION
## Summary
- expose partition stats via NodeCluster
- document the new API near the Hotspot Metrics section

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6852e76861208331b6a5a1ebdda1001f