### PR TITLE
Add automatic hot partition splitting

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,12 @@ faixas. Sem parâmetro, um ponto médio aproximado é utilizado.
 cluster.split_partition(0, 'g')  # cria ['a','g') e ['g','m')
 ```
 
+Também é possível deixar que o cluster monitore as métricas e execute a divisão
+automaticamente. Chame `check_hot_partitions(threshold=2.0, min_keys=2)` de
+tempos em tempos; para cada partição que ultrapassar o limite de operações e
+tiver pelo menos `min_keys` chaves distintas acessadas, `split_partition()` será
+invocado e os contadores reiniciados com `reset_metrics()`.
+
 A divisão apenas redireciona novas escritas; os dados existentes permanecem em
 sua localização original.
 


### PR DESCRIPTION
## Summary
- support automatic hot partition detection via `check_hot_partitions`
- reset metrics after partition split
- document how to use the new method

## Testing
- `pytest -q` *(fails: ReplicationManagerTest::test_offline_node_eventual_convergence)*
- `pytest tests/test_replication.py::ReplicationManagerTest::test_offline_node_eventual_convergence -vv`


------
https://chatgpt.com/codex/tasks/task_e_6852f87b2fa883318951867a7ca537e9