### PR TITLE
Add automated partition splitting tests

### DIFF
--- a/tests/test_auto_split.py
+++ b/tests/test_auto_split.py
@@ -1,0 +1,56 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class AutoSplitRangeTest(unittest.TestCase):
+    def test_auto_split_range_partition(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ranges = [("a", "m"), ("m", "z")]
+            cluster = NodeCluster(base_path=tmpdir, num_nodes=2, key_ranges=ranges)
+            try:
+                cluster.reset_metrics()
+                for i in range(5):
+                    cluster.put(0, "a", f"v{i}")
+                    cluster.put(0, "b", f"v{i}")
+                cluster.check_hot_partitions(threshold=1.0)
+                cluster.put(0, "ga", "val")
+                time.sleep(0.2)
+                self.assertEqual(cluster.num_partitions, 3)
+                node_new = cluster.partitions[1][1]
+                node_old = cluster.partitions[0][1]
+                self.assertTrue(node_new.client.get("ga"))
+                self.assertFalse(node_old.client.get("ga"))
+            finally:
+                cluster.shutdown()
+
+
+class AutoSplitHashTest(unittest.TestCase):
+    def test_auto_split_hash_partition(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                replication_factor=1,
+                partition_strategy="hash",
+                num_partitions=2,
+            )
+            try:
+                cluster.reset_metrics()
+                for i in range(3):
+                    cluster.put(0, "a", f"v{i}")
+                    cluster.put(0, "b", f"v{i}")
+                cluster.check_hot_partitions(threshold=1.0)
+                self.assertEqual(cluster.num_partitions, 3)
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add auto-splitting tests for range and hash partitions

## Testing
- `pytest tests/test_auto_split.py::AutoSplitRangeTest::test_auto_split_range_partition -q`
- `pytest tests/test_auto_split.py::AutoSplitHashTest::test_auto_split_hash_partition -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530b5fbbc483319a888ea2f45cfc3e