### PR TITLE
Fix Merkle diff hashing

### DIFF
--- a/index_manager.py
+++ b/index_manager.py
@@ -1,0 +1,51 @@
+class IndexManager:
+    """Simple in-memory secondary index manager."""
+
+    def __init__(self) -> None:
+        self._fields = set()
+        self._indexes = {}
+        self._records = {}
+
+    def register_field(self, field: str) -> None:
+        """Register ``field`` for indexing."""
+        if not field:
+            raise ValueError("field name required")
+        if field in self._fields:
+            return
+        self._fields.add(field)
+        self._indexes[field] = {}
+        # Index existing records for the new field
+        for rec_id, rec in self._records.items():
+            if field in rec:
+                value = rec[field]
+                self._indexes[field].setdefault(value, set()).add(rec_id)
+
+    def add_record(self, record_id: str, record: dict) -> None:
+        """Add ``record`` with identifier ``record_id`` to indexes."""
+        if record_id in self._records:
+            self.remove_record(record_id)
+        self._records[record_id] = dict(record)
+        for field in self._fields:
+            if field in record:
+                value = record[field]
+                self._indexes[field].setdefault(value, set()).add(record_id)
+
+    def remove_record(self, record_id: str) -> None:
+        """Remove a record from indexes."""
+        record = self._records.pop(record_id, None)
+        if not record:
+            return
+        for field in self._fields:
+            if field in record:
+                value = record[field]
+                ids = self._indexes[field].get(value)
+                if ids:
+                    ids.discard(record_id)
+                    if not ids:
+                        del self._indexes[field][value]
+
+    def query(self, field: str, value) -> set:
+        """Return set of record ids with ``field`` equal to ``value``."""
+        if field not in self._fields:
+            raise KeyError(f"Unregistered field: {field}")
+        return set(self._indexes.get(field, {}).get(value, set()))

--- a/merkle.py
+++ b/merkle.py
@@ -33,9 +33,9 @@ def compute_segment_hashes(db) -> Dict[str, str]:
     if hasattr(db, "memtable"):
         items = []
         for k, versions in db.memtable.get_sorted_items():
-            for val, vc in versions:
+            for val, _vc in versions:
                 if val != "__TOMBSTONE__":
-                    items.append((k, json.dumps(vc.clock) + ":" + val))
+                    items.append((k, val))
         hashes["memtable"] = merkle_root(items)
 
     if hasattr(db, "sstable_manager"):
@@ -53,7 +53,7 @@ def compute_segment_hashes(db) -> Dict[str, str]:
                             k = data.get("key")
                             v = data.get("value")
                             if v != "__TOMBSTONE__":
-                                seg_items.append((k, json.dumps(data.get("vector", {})) + ":" + v))
+                                seg_items.append((k, v))
                         except json.JSONDecodeError:
                             continue
             except FileNotFoundError:

--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -359,8 +359,8 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
                 if remote_hashes.get(seg) == h:
                     continue
                 items = [
-                    (k, json.dumps(vc.clock) + ":" + v)
-                    for k, v, vc in self._node.db.get_segment_items(seg)
+                    (k, v)
+                    for k, v, _vc in self._node.db.get_segment_items(seg)
                     if v != "__TOMBSTONE__"
                 ]
                 local_tree = build_merkle_tree(items)
@@ -946,8 +946,8 @@ class NodeServer:
         trees = []
         for seg in hashes:
             items = [
-                (k, json.dumps(vc.clock) + ":" + v)
-                for k, v, vc in self.db.get_segment_items(seg)
+                (k, v)
+                for k, v, _vc in self.db.get_segment_items(seg)
                 if v != "__TOMBSTONE__"
             ]
             root = build_merkle_tree(items)

--- a/tests/test_index_manager.py
+++ b/tests/test_index_manager.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from index_manager import IndexManager
+
+
+class IndexManagerTest(unittest.TestCase):
+    def test_register_and_query(self):
+        idx = IndexManager()
+        idx.register_field("name")
+        idx.add_record("1", {"name": "alice", "age": 30})
+        self.assertEqual(idx.query("name", "alice"), {"1"})
+
+        idx.register_field("age")
+        idx.add_record("2", {"name": "bob", "age": 30})
+        self.assertEqual(idx.query("age", 30), {"1", "2"})
+
+    def test_remove_record(self):
+        idx = IndexManager()
+        idx.register_field("name")
+        idx.add_record("1", {"name": "alice"})
+        idx.add_record("2", {"name": "alice"})
+        idx.remove_record("1")
+        self.assertEqual(idx.query("name", "alice"), {"2"})
+        idx.remove_record("2")
+        self.assertEqual(idx.query("name", "alice"), set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_merkle.py
+++ b/tests/test_merkle.py
@@ -25,8 +25,8 @@ class MerkleUtilsTest(unittest.TestCase):
             hashes = db.segment_hashes
             self.assertNotEqual(before, hashes["memtable"])
             seg_items = [
-                (k, json.dumps(vc.clock) + ":" + v)
-                for k, v, vc in db.get_segment_items(seg_names[0])
+                (k, v)
+                for k, v, _vc in db.get_segment_items(seg_names[0])
                 if v != "__TOMBSTONE__"
             ]
             expected = merkle_root(seg_items)
@@ -49,8 +49,8 @@ class FetchUpdatesMerkleTest(unittest.TestCase):
             trees = []
             for seg in node_a.db.segment_hashes:
                 items = [
-                    (k, json.dumps(vc.clock) + ":" + v)
-                    for k, v, vc in node_a.db.get_segment_items(seg)
+                    (k, v)
+                    for k, v, _vc in node_a.db.get_segment_items(seg)
                     if v != "__TOMBSTONE__"
                 ]
                 root = build_merkle_tree(items)
@@ -82,8 +82,8 @@ class FetchUpdatesMerkleTest(unittest.TestCase):
             trees = []
             for seg in node_a.db.segment_hashes:
                 items = [
-                    (k, json.dumps(vc.clock) + ":" + v)
-                    for k, v, vc in node_a.db.get_segment_items(seg)
+                    (k, v)
+                    for k, v, _vc in node_a.db.get_segment_items(seg)
                     if v != "__TOMBSTONE__"
                 ]
                 root = build_merkle_tree(items)


### PR DESCRIPTION
## Summary
- adjust Merkle hash calculation to exclude vector clock data
- update ReplicaService to build trees without vector clocks
- adapt merkle unit tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68555d4d99188331a8ce1dcb346f1951