### PR TITLE
Add NodeServer.query_index and tests

### DIFF
--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -555,6 +555,10 @@ class NodeServer:
         """Update the cached partition map."""
         self.partition_map = new_map or {}
 
+    def query_index(self, field: str, value):
+        """Return keys matching field/value in the secondary index."""
+        return self.index_manager.query(field, value)
+
     def _iter_peers(self):
         """Yield tuples of (host, port, node_id, client) for all peers."""
         if self.clients_by_id:

--- a/tests/test_node_query_index.py
+++ b/tests/test_node_query_index.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replica.grpc_server import NodeServer, ReplicaService
+from replica import replication_pb2
+
+
+class NodeQueryIndexTest(unittest.TestCase):
+    def test_query_returns_matching_keys(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, index_fields=["name"])
+            service = ReplicaService(node)
+
+            service.Put(replication_pb2.KeyValue(key="k1", value='{"name": "alice"}', timestamp=1), None)
+            service.Put(replication_pb2.KeyValue(key="k2", value='{"name": "bob"}', timestamp=2), None)
+            service.Put(replication_pb2.KeyValue(key="k3", value='{"name": "alice"}', timestamp=3), None)
+
+            result = sorted(node.query_index("name", "alice"))
+            self.assertEqual(result, ["k1", "k3"])
+            node.db.close()
+
+    def test_query_empty_after_delete(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, index_fields=["name"])
+            service = ReplicaService(node)
+
+            service.Put(replication_pb2.KeyValue(key="k1", value='{"name": "alice"}', timestamp=1), None)
+            service.Delete(replication_pb2.KeyRequest(key="k1", timestamp=2), None)
+
+            self.assertEqual(node.query_index("name", "alice"), [])
+            node.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `query_index` in NodeServer
- add tests covering the new helper

## Testing
- `PYTHONPATH=. pytest -q tests/test_index_manager.py tests/test_node_query_index.py`

------
https://chatgpt.com/codex/tasks/task_e_6855941fba5883319252e9b3414b273f