### PR TITLE
Implement thread-safe IndexManager

### DIFF
--- a/index_manager.py
+++ b/index_manager.py
@@ -1,45 +1,48 @@
 import json
-from typing import Iterable, Dict, Set, Any, List
+import threading
+from typing import Iterable, Any
+
 
 class IndexManager:
-    """Simple in-memory secondary index manager."""
+    """In-memory secondary index manager with thread safety."""
 
-    def __init__(self, fields: Iterable[str] | None = None) -> None:
-        self.fields = list(fields) if fields else []
-        self.indexes: Dict[str, Dict[Any, Set[str]]] = {f: {} for f in self.fields}
+    def __init__(self, fields: Iterable[str]) -> None:
+        self.fields = list(fields)
+        self.indexes: dict[str, dict[Any, set[str]]] = {
+            f: {} for f in self.fields
+        }
+        self._lock = threading.Lock()
 
     def add_record(self, key: str, value: str) -> None:
-        if not self.fields:
-            return
         try:
             data = json.loads(value)
         except Exception:
             return
-        for field in self.fields:
-            if field in data:
-                val = data[field]
-                idx = self.indexes.setdefault(field, {})
-                idx.setdefault(val, set()).add(key)
+        with self._lock:
+            for field in self.fields:
+                if field in data:
+                    idx = self.indexes.setdefault(field, {})
+                    idx.setdefault(data[field], set()).add(key)
 
     def remove_record(self, key: str, value: str) -> None:
-        if not self.fields:
-            return
         try:
             data = json.loads(value)
         except Exception:
             return
-        for field in self.fields:
-            if field in data:
-                val = data[field]
-                idx = self.indexes.get(field)
-                if not idx:
-                    continue
-                keys = idx.get(val)
-                if not keys:
-                    continue
-                keys.discard(key)
-                if not keys:
-                    idx.pop(val, None)
+        with self._lock:
+            for field in self.fields:
+                if field in data:
+                    val = data[field]
+                    idx = self.indexes.get(field)
+                    if not idx:
+                        continue
+                    keys = idx.get(val)
+                    if not keys:
+                        continue
+                    keys.discard(key)
+                    if not keys:
+                        idx.pop(val, None)
 
-    def query(self, field: str, value: Any) -> List[str]:
-        return list(self.indexes.get(field, {}).get(value, set()))
+    def query(self, field: str, value) -> list[str]:
+        with self._lock:
+            return list(self.indexes.get(field, {}).get(value, set()))


### PR DESCRIPTION
## Summary
- reimplement `index_manager.py`
- add thread lock and JSON parsing for add/remove/query operations
- address style issues in IndexManager

## Testing
- `PYTHONPATH=. pytest tests/test_index_manager.py tests/test_node_query_index.py tests/test_node_indexing.py -q`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559fd3dd588331af1a8cf829a7d82d