### PR TITLE
Add index rebuild persistence test

### DIFF
--- a/tests/test_node_indexing.py
+++ b/tests/test_node_indexing.py
@@ -31,6 +31,44 @@ class NodeIndexingTest(unittest.TestCase):
 
             node.db.close()
 
+    def test_index_rebuild_after_restart(self):
+        """Ensure index persists when NodeServer is recreated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, index_fields=["age"])
+            service = ReplicaService(node)
+
+            service.Put(
+                replication_pb2.KeyValue(key="u1", value='{"age": 20}', timestamp=1),
+                None,
+            )
+            service.Put(
+                replication_pb2.KeyValue(key="u2", value='{"age": 25}', timestamp=2),
+                None,
+            )
+
+            service.Put(
+                replication_pb2.KeyValue(key="u1", value='{"age": 22}', timestamp=3),
+                None,
+            )
+            service.Delete(replication_pb2.KeyRequest(key="u2", timestamp=4), None)
+
+            # Before closing, verify current index state
+            self.assertEqual(sorted(node.query_index("age", 22)), ["u1"])
+            self.assertEqual(node.query_index("age", 20), [])
+            self.assertEqual(node.query_index("age", 25), [])
+
+            node.db.close()
+
+            # Recreate node pointing to the same directory
+            node = NodeServer(db_path=tmpdir, index_fields=["age"])
+
+            # Index should be rebuilt from on-disk data
+            self.assertEqual(sorted(node.query_index("age", 22)), ["u1"])
+            self.assertEqual(node.query_index("age", 20), [])
+            self.assertEqual(node.query_index("age", 25), [])
+
+            node.db.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- check that NodeServer rebuilds indexes after restart

## Testing
- `pytest -q tests/test_node_indexing.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d8ff3ed083319b1d3a881ed55b4f