### PR TITLE
Support index_fields in NodeCluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,24 @@ service.Put(replication_pb2.KeyValue(key='k2', value='{"name": "bob"}', timestam
 print(node.query_index('name', 'alice'))  # ['k1']
 ```
 
+Usando `NodeCluster`:
+
+```python
+from replication import NodeCluster
+from replica.grpc_server import NodeServer
+import json
+
+cluster = NodeCluster('/tmp/cluster_idx', num_nodes=1, index_fields=['name'])
+cluster.put(0, 'u1', json.dumps({'name': 'alice'}))
+
+# Após as operações é possível criar um `NodeServer` apontando
+# para o diretório do nó para consultar o índice
+node = NodeServer('/tmp/cluster_idx/node_0', index_fields=['name'])
+print(node.query_index('name', 'alice'))  # ['u1']
+node.db.close()
+cluster.shutdown()
+```
+
 ## Sharding e Roteamento
 
 Esta seção resume como o cluster divide os dados e encaminha as requisições. Sistemas como **HBase** utilizam partições por faixa de valores, enquanto o **Cassandra** popularizou o particionamento por hash.

--- a/replication.py
+++ b/replication.py
@@ -73,6 +73,7 @@ class NodeCluster:
         max_transfer_rate: int | None = None,
         enable_forwarding: bool = False,
         load_balance_reads: bool = False,
+        index_fields: list[str] | None = None,
     ):
         self.base_path = base_path
         if os.path.exists(base_path):
@@ -103,6 +104,7 @@ class NodeCluster:
         self.max_transfer_rate = max_transfer_rate
         self.enable_forwarding = enable_forwarding
         self.load_balance_reads = load_balance_reads
+        self.index_fields = index_fields
         self.key_ranges = None
         self.partitions: list[tuple[tuple, ClusterNode]] = []
         self.partition_map: dict[int, str] = {}
@@ -191,6 +193,7 @@ class NodeCluster:
                     "enable_forwarding": self.enable_forwarding,
                     "partition_modulus": self.num_partitions if self.ring is None else None,
                     "node_index": i if self.ring is None else None,
+                    "index_fields": self.index_fields,
                 },
                 daemon=True,
             )
@@ -897,6 +900,7 @@ class NodeCluster:
             kwargs={
                 "consistency_mode": self.consistency_mode,
                 "enable_forwarding": self.enable_forwarding,
+                "index_fields": self.index_fields,
             },
             daemon=True,
         )

--- a/tests/test_cluster_indexing.py
+++ b/tests/test_cluster_indexing.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import tempfile
+import time
+import json
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+from replica.grpc_server import NodeServer
+
+
+class ClusterIndexingTest(unittest.TestCase):
+    def test_cluster_nodes_build_indexes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(base_path=tmpdir, num_nodes=1, index_fields=["name"])
+            try:
+                cluster.put(0, "u1", json.dumps({"name": "alice"}))
+                # allow async replication/index update
+                time.sleep(0.5)
+            finally:
+                cluster.shutdown()
+
+            node = NodeServer(os.path.join(tmpdir, "node_0"), index_fields=["name"])
+            try:
+                self.assertEqual(sorted(node.query_index("name", "alice")), ["u1"])
+            finally:
+                node.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow NodeCluster to accept `index_fields` and forward to nodes
- keep this configuration when adding new nodes
- document how to use `NodeCluster(index_fields=[...])`
- add tests demonstrating that node indexes work when cluster is created

## Testing
- `python -m pytest tests/test_cluster_indexing.py -q`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855dbe75a9c833188dd52a72e5890e8