### PR TITLE
Add index owner helpers

### DIFF
--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -588,6 +588,12 @@ class NodeServer:
         """Return list of keys matching ``field``/``value`` in the secondary index."""
         return self.index_manager.query(field, value)
 
+    def get_index_owner(self, field: str, value) -> str:
+        """Return node_id responsible for ``field``/``value`` index key."""
+        key = f"idx:{field}:{value}"
+        # Delegate to ReplicaService logic for owner determination
+        return self.service._owner_for_key(key)
+
     def _iter_peers(self):
         """Yield tuples of (host, port, node_id, client) for all peers."""
         if self.clients_by_id:


### PR DESCRIPTION
## Summary
- expose index key ownership helper in `NodeServer`
- provide `NodeCluster.get_index_owner` for quick lookups
- ensure partition routing for index keys matches node routing logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ba65d0908331bf158f51a0004c41