### PR TITLE
Enable global index queries via ReplicaService

### DIFF
--- a/replica/grpc_server.py
+++ b/replica/grpc_server.py
@@ -504,7 +504,10 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             value = json.loads(request.value)
         except Exception:
             value = request.value
-        keys = self._node.query_index(request.field, value)
+        if request.field in getattr(self._node.global_index_manager, "fields", []):
+            keys = self._node.global_index_manager.query(request.field, value)
+        else:
+            keys = self._node.query_index(request.field, value)
         return replication_pb2.KeyList(keys=keys)
 
 

--- a/tests/test_replica_list_by_index.py
+++ b/tests/test_replica_list_by_index.py
@@ -24,6 +24,24 @@ class ReplicaListByIndexTest(unittest.TestCase):
             self.assertEqual(list(resp.keys), ["k1"])
             node.db.close()
 
+    def test_service_returns_global_indexed_keys(self):
+        """ListByIndex should use the global index when querying a global field."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, global_index_fields=["tag"])
+            service = ReplicaService(node)
+
+            service.Put(
+                replication_pb2.KeyValue(
+                    key="k1", value=json.dumps({"tag": "blue"}), timestamp=1
+                ),
+                None,
+            )
+
+            req = replication_pb2.IndexQuery(field="tag", value="blue")
+            resp = service.ListByIndex(req, None)
+            self.assertEqual(list(resp.keys), ["k1"])
+            node.db.close()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- route ListByIndex to GlobalIndexManager when field is global
- test ListByIndex for global index lookups

## Testing
- `pytest -q tests/test_replica_list_by_index.py::ReplicaListByIndexTest::test_service_returns_indexed_keys -q`
- `pytest -q tests/test_replica_list_by_index.py::ReplicaListByIndexTest::test_service_returns_global_indexed_keys -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6856cc80efe88331acbf24ee620e1679