### PR TITLE
Default partitions for hash clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ Esta seção resume como o cluster divide os dados e encaminha as requisições.
                         num_partitions=6)
   ```
   `num_partitions` define quantas faixas lógicas o hash cria e distribui em round-robin.
+  Quando omitido, o cluster cria 128 partições por padrão (sem anel de hash).
 
 ### Roteamento
 
@@ -490,6 +491,7 @@ cluster = NodeCluster('/tmp/hash_cluster', num_nodes=3,
                       partition_strategy='hash',
                       replication_factor=1)
 ```
+Se `num_partitions` não for informado, o cluster cria 128 partições por padrão (quando não há anel de hash).
 
 Para pré-criar um número maior de partições do que nós, defina
 `num_partitions` explicitamente. As partições extras serão distribuídas em

--- a/tests/test_partition_api.py
+++ b/tests/test_partition_api.py
@@ -30,10 +30,17 @@ class HashPartitionAPITest(unittest.TestCase):
 
                 k1 = compose_key("alpha", "a")
                 k2 = compose_key("bravo", "a")
-                self.assertTrue(cluster.nodes[pid1].client.get(k1))
-                self.assertFalse(cluster.nodes[pid1].client.get(k2))
-                self.assertTrue(cluster.nodes[pid2].client.get(k2))
-                self.assertFalse(cluster.nodes[pid2].client.get(k1))
+                idx1 = int(cluster.partition_map[pid1].split("_")[1])
+                idx2 = int(cluster.partition_map[pid2].split("_")[1])
+                for i, n in enumerate(cluster.nodes):
+                    if i == idx1:
+                        self.assertTrue(n.client.get(k1))
+                    else:
+                        self.assertFalse(n.client.get(k1))
+                    if i == idx2:
+                        self.assertTrue(n.client.get(k2))
+                    else:
+                        self.assertFalse(n.client.get(k2))
             finally:
                 cluster.shutdown()
 
@@ -56,9 +63,10 @@ class GetRangeTest(unittest.TestCase):
 
                 pid = cluster.get_partition_id("alpha")
                 k = compose_key("alpha", "a")
-                self.assertTrue(cluster.nodes[pid].client.get(k))
+                idx = int(cluster.partition_map[pid].split("_")[1])
+                self.assertTrue(cluster.nodes[idx].client.get(k))
                 for i, n in enumerate(cluster.nodes):
-                    if i != pid:
+                    if i != idx:
                         self.assertFalse(n.client.get(k))
 
                 items = cluster.get_range("alpha", "a", "c")

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -29,6 +29,7 @@ class RebalanceHashClusterTest(unittest.TestCase):
                 num_nodes=2,
                 replication_factor=1,
                 partition_strategy="hash",
+                num_partitions=6,
             )
             try:
                 keys = self._partition_keys(cluster)
@@ -49,6 +50,7 @@ class RebalanceHashClusterTest(unittest.TestCase):
                 num_nodes=3,
                 replication_factor=2,
                 partition_strategy="hash",
+                num_partitions=6,
             )
             try:
                 keys = self._partition_keys(cluster)


### PR DESCRIPTION
## Summary
- add `DEFAULT_NUM_PARTITIONS` constant
- use 128 partitions by default on simple hash clusters
- adjust `add_node` to avoid duplicating nodes in `HashPartitioner`
- document new default in README
- update tests to match the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859c94c33b883319ec983652ee77311