### PR TITLE
Add partition item counts tracking

### DIFF
--- a/tests/test_partition_item_counts.py
+++ b/tests/test_partition_item_counts.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class PartitionItemCountTest(unittest.TestCase):
+    def test_counts_increment_and_decrement(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=1,
+                replication_factor=1,
+                partition_strategy="hash",
+                num_partitions=2,
+            )
+            try:
+                cluster.reset_metrics()
+                cluster.put(0, "a", "v1")
+                cluster.put(0, "a", "v2")
+                cluster.put(0, "b", "v3")
+                counts = cluster.get_partition_item_counts()
+                self.assertEqual(sum(counts.values()), 2)
+                cluster.delete(0, "a")
+                counts = cluster.get_partition_item_counts()
+                self.assertEqual(sum(counts.values()), 1)
+            finally:
+                cluster.shutdown()
+
+    def test_reset_metrics_clears_counts(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=1,
+                replication_factor=1,
+                partition_strategy="hash",
+                num_partitions=2,
+            )
+            try:
+                cluster.put(0, "a", "v1")
+                cluster.reset_metrics()
+                counts = cluster.get_partition_item_counts()
+                self.assertTrue(all(v == 0 for v in counts.values()))
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- track item counts per partition in `NodeCluster`
- reset and expose the counters
- consider item counts when splitting/merging partitions
- test the new counters

## Testing
- `pytest -q tests/test_partition_item_counts.py tests/test_cold_partitions.py::ColdPartitionMergeTest::test_merge_after_low_activity -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f6bc82808331a237b5d029d614c0