### PR TITLE
Implement consistent hash partitioner

### DIFF
--- a/tests/test_consistent_hash_partitioner.py
+++ b/tests/test_consistent_hash_partitioner.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+import random
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from partitioning import ConsistentHashPartitioner
+
+
+class ConsistentHashPartitionerTest(unittest.TestCase):
+    def test_uniform_distribution(self):
+        random.seed(42)
+        nodes = [SimpleNamespace(node_id=f"n{i}") for i in range(3)]
+        part = ConsistentHashPartitioner()
+        for n in nodes:
+            part.add_node(n, weight=10)
+
+        keys = [f"k{i}" for i in range(300)]
+        counts = {n.node_id: 0 for n in nodes}
+        for k in keys:
+            pid = part.get_partition_id(k)
+            nid = part.get_partition_map()[pid]
+            counts[nid] += 1
+
+        expected = len(keys) / len(nodes)
+        for c in counts.values():
+            self.assertLessEqual(abs(c - expected), expected * 0.3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `ConsistentHashPartitioner` wrapping `HashRing`
- generate random 160-bit tokens for nodes
- expose ring index lookup and partition map helpers
- test uniform key distribution using the new partitioner

## Testing
- `pip install -q -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6859fd342ce88331bb138fb8eabec57b