### PR TITLE
Update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -743,7 +743,8 @@ python -m unittest tests/test_routing.py tests/test_smart_driver.py -v
 ## Testes
 
 Execute a bateria de testes para validar o sistema. Instale antes as
-dependências listadas em `requirements.txt`:
+dependências listadas em `requirements.txt` (especialmente `grpcio`
+e `protobuf` utilizados nos serviços gRPC):
 ```bash
 pip install -r requirements.txt
 python -m unittest discover -s tests -v


### PR DESCRIPTION
## Summary
- clarify need to install grpcio/protobuf before running tests

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_685a82f49c148331898c3ccaf5e67fcb