### PR TITLE
Add optional router to NodeCluster

### DIFF
--- a/router_server.py
+++ b/router_server.py
@@ -29,7 +29,10 @@ class RouterService(replication_pb2_grpc.ReplicaServicer):
         pk, ck = self._split_key(key)
         pid = self.cluster.get_partition_id(pk, ck)
         owner = self.partition_map.get(pid)
-        return self.clients_by_id[owner]
+        client = self.clients_by_id[owner]
+        # Ensure gRPC channel is initialized after forking
+        client._ensure_channel()
+        return client
 
     # RPC methods -------------------------------------------------------
     def Put(self, request, context):

--- a/tests/test_router_server.py
+++ b/tests/test_router_server.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from replication import NodeCluster
+
+
+class RouterServerTest(unittest.TestCase):
+    def test_router_process_put_get(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(base_path=tmpdir, num_nodes=2, start_router=True)
+            try:
+                cluster.router_client.put("rkey", "v1")
+                time.sleep(0.5)
+                self.assertEqual(cluster.get(0, "rkey"), "v1")
+                self.assertTrue(cluster.router_process.is_alive())
+            finally:
+                cluster.shutdown()
+            self.assertFalse(cluster.router_process.is_alive())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `start_router` and `router_port` options
- run router server process when requested
- store router client for tests
- shut down router on cluster shutdown
- ensure router reconnects after fork
- add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ab375772c8331a712fc3c68813bd6