### PR TITLE
Enable load-balanced reads in Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,12 +727,13 @@ print(router.get('other'))
 ### Cliente consciente
 
 O `Driver` mantém em cache o mapa de partições e atualiza-o sempre que recebe um
-erro `NotOwner`.
+erro `NotOwner`. Ele também pode balancear leituras entre as réplicas através do
+parâmetro opcional `load_balance_reads` (padrão: herda do cluster).
 
 ```python
 cluster = NodeCluster('/tmp/driver', num_nodes=3,
                       partition_strategy='hash', enable_forwarding=False)
-driver = Driver(cluster)
+driver = Driver(cluster, load_balance_reads=True)
 driver.put('u', 'key', 'valor')
 print(driver.get('u', 'key'))
 ```


### PR DESCRIPTION
## Summary
- inherit load_balance_reads from cluster when creating Driver
- randomly pick replicas via ring to distribute reads
- update tests for Driver to verify load-balanced reads
- document `load_balance_reads` for Driver in README

## Testing
- `python -m unittest tests/test_smart_driver.py -v`

------
https://chatgpt.com/codex/tasks/task_e_685ac64478408331858c773143e9a731