### PR TITLE
Add MetadataService watchers and registry integration

### DIFF
--- a/metadata_service.py
+++ b/metadata_service.py
@@ -1,6 +1,8 @@
 import time
 import grpc
 from concurrent import futures
+import threading
+import queue
 
 from replica import metadata_pb2, metadata_pb2_grpc, replication_pb2
 
@@ -13,6 +15,15 @@ class MetadataService(metadata_pb2_grpc.MetadataServiceServicer):
         self.last_seen: dict[str, float] = {}
         self.partition_map: dict[int, str] = {}
         self.server = None
+        self._watchers: list[queue.Queue] = []
+
+    def _broadcast(self) -> None:
+        state = self._cluster_state()
+        for q in list(self._watchers):
+            try:
+                q.put_nowait(state)
+            except Exception:
+                pass
 
     # internal helpers -------------------------------------------------
     def _cluster_state(self) -> metadata_pb2.ClusterState:
@@ -28,24 +39,48 @@ class MetadataService(metadata_pb2_grpc.MetadataServiceServicer):
         node = request.node
         self.nodes[node.node_id] = (node.host, node.port)
         self.last_seen[node.node_id] = time.time()
-        return self._cluster_state()
+        state = self._cluster_state()
+        self._broadcast()
+        return state
 
     def Heartbeat(self, request, context):
         self.last_seen[request.node_id] = time.time()
-        return self._cluster_state()
+        state = self._cluster_state()
+        self._broadcast()
+        return state
 
     def GetClusterState(self, request, context):
         return self._cluster_state()
+
+    def WatchClusterState(self, request, context):
+        q: queue.Queue = queue.Queue()
+        self._watchers.append(q)
+        def _remove():
+            if q in self._watchers:
+                self._watchers.remove(q)
+            return True
+        context.add_callback(_remove)
+        q.put(self._cluster_state())
+        while True:
+            try:
+                state = q.get(timeout=1.0)
+            except queue.Empty:
+                if not context.is_active():
+                    break
+                continue
+            yield state
 
     def UpdateClusterState(self, request, context):
         """Replace the registry data with provided cluster state."""
         self.nodes = {n.node_id: (n.host, n.port) for n in request.nodes}
         self.partition_map = dict(request.partition_map.items)
+        self._broadcast()
         return replication_pb2.Empty()
 
     # helpers for the cluster -----------------------------------------
     def update_partition_map(self, mapping: dict[int, str]):
         self.partition_map = dict(mapping)
+        self._broadcast()
 
 
 def run_metadata_service(host="localhost", port=9100):

--- a/replica/metadata.proto
+++ b/replica/metadata.proto
@@ -27,4 +27,5 @@ service MetadataService {
   rpc Heartbeat(HeartbeatRequest) returns (ClusterState);
   rpc GetClusterState(replication.Empty) returns (ClusterState);
   rpc UpdateClusterState(ClusterState) returns (replication.Empty);
+  rpc WatchClusterState(replication.Empty) returns (stream ClusterState);
 }

--- a/replica/metadata_pb2.py
+++ b/replica/metadata_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from replica import replication_pb2 as replica_dot_replication__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16replica/metadata.proto\x12\x08metadata\x1a\x19replica/replication.proto\"7\n\x08NodeInfo\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x0c\n\x04host\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\x05\"3\n\x0fRegisterRequest\x12 \n\x04node\x18\x01 \x01(\x0b\x32\x12.metadata.NodeInfo\"#\n\x10HeartbeatRequest\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"c\n\x0c\x43lusterState\x12!\n\x05nodes\x18\x01 \x03(\x0b\x32\x12.metadata.NodeInfo\x12\x30\n\rpartition_map\x18\x02 \x01(\x0b\x32\x19.replication.PartitionMap2\x96\x02\n\x0fMetadataService\x12\x41\n\x0cRegisterNode\x12\x19.metadata.RegisterRequest\x1a\x16.metadata.ClusterState\x12?\n\tHeartbeat\x12\x1a.metadata.HeartbeatRequest\x1a\x16.metadata.ClusterState\x12=\n\x0fGetClusterState\x12\x12.replication.Empty\x1a\x16.metadata.ClusterState\x12@\n\x12UpdateClusterState\x12\x16.metadata.ClusterState\x1a\x12.replication.Emptyb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x16replica/metadata.proto\x12\x08metadata\x1a\x19replica/replication.proto\"7\n\x08NodeInfo\x12\x0f\n\x07node_id\x18\x01 \x01(\t\x12\x0c\n\x04host\x18\x02 \x01(\t\x12\x0c\n\x04port\x18\x03 \x01(\x05\"3\n\x0fRegisterRequest\x12 \n\x04node\x18\x01 \x01(\x0b\x32\x12.metadata.NodeInfo\"#\n\x10HeartbeatRequest\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"c\n\x0c\x43lusterState\x12!\n\x05nodes\x18\x01 \x03(\x0b\x32\x12.metadata.NodeInfo\x12\x30\n\rpartition_map\x18\x02 \x01(\x0b\x32\x19.replication.PartitionMap2\xd9\x02\n\x0fMetadataService\x12\x41\n\x0cRegisterNode\x12\x19.metadata.RegisterRequest\x1a\x16.metadata.ClusterState\x12?\n\tHeartbeat\x12\x1a.metadata.HeartbeatRequest\x1a\x16.metadata.ClusterState\x12=\n\x0fGetClusterState\x12\x12.replication.Empty\x1a\x16.metadata.ClusterState\x12@\n\x12UpdateClusterState\x12\x16.metadata.ClusterState\x1a\x12.replication.Empty\x12\x41\n\x11WatchClusterState\x12\x12.replication.Empty\x1a\x16.metadata.ClusterState0\x01\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -41,5 +41,5 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_CLUSTERSTATE']._serialized_start=210
   _globals['_CLUSTERSTATE']._serialized_end=309
   _globals['_METADATASERVICE']._serialized_start=312
-  _globals['_METADATASERVICE']._serialized_end=590
+  _globals['_METADATASERVICE']._serialized_end=657
 # @@protoc_insertion_point(module_scope)

--- a/replica/metadata_pb2_grpc.py
+++ b/replica/metadata_pb2_grpc.py
@@ -6,7 +6,7 @@ import warnings
 from replica import metadata_pb2 as replica_dot_metadata__pb2
 from replica import replication_pb2 as replica_dot_replication__pb2
 
-GRPC_GENERATED_VERSION = '1.73.0'
+GRPC_GENERATED_VERSION = '1.73.1'
 GRPC_VERSION = grpc.__version__
 _version_not_supported = False
 
@@ -55,6 +55,11 @@ class MetadataServiceStub(object):
                 request_serializer=replica_dot_metadata__pb2.ClusterState.SerializeToString,
                 response_deserializer=replica_dot_replication__pb2.Empty.FromString,
                 _registered_method=True)
+        self.WatchClusterState = channel.unary_stream(
+                '/metadata.MetadataService/WatchClusterState',
+                request_serializer=replica_dot_replication__pb2.Empty.SerializeToString,
+                response_deserializer=replica_dot_metadata__pb2.ClusterState.FromString,
+                _registered_method=True)
 
 
 class MetadataServiceServicer(object):
@@ -84,6 +89,12 @@ class MetadataServiceServicer(object):
         context.set_details('Method not implemented!')
         raise NotImplementedError('Method not implemented!')
 
+    def WatchClusterState(self, request, context):
+        """Missing associated documentation comment in .proto file."""
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details('Method not implemented!')
+        raise NotImplementedError('Method not implemented!')
+
 
 def add_MetadataServiceServicer_to_server(servicer, server):
     rpc_method_handlers = {
@@ -106,6 +117,11 @@ def add_MetadataServiceServicer_to_server(servicer, server):
                     servicer.UpdateClusterState,
                     request_deserializer=replica_dot_metadata__pb2.ClusterState.FromString,
                     response_serializer=replica_dot_replication__pb2.Empty.SerializeToString,
+            ),
+            'WatchClusterState': grpc.unary_stream_rpc_method_handler(
+                    servicer.WatchClusterState,
+                    request_deserializer=replica_dot_replication__pb2.Empty.FromString,
+                    response_serializer=replica_dot_metadata__pb2.ClusterState.SerializeToString,
             ),
     }
     generic_handler = grpc.method_handlers_generic_handler(
@@ -216,6 +232,33 @@ class MetadataService(object):
             '/metadata.MetadataService/UpdateClusterState',
             replica_dot_metadata__pb2.ClusterState.SerializeToString,
             replica_dot_replication__pb2.Empty.FromString,
+            options,
+            channel_credentials,
+            insecure,
+            call_credentials,
+            compression,
+            wait_for_ready,
+            timeout,
+            metadata,
+            _registered_method=True)
+
+    @staticmethod
+    def WatchClusterState(request,
+            target,
+            options=(),
+            channel_credentials=None,
+            call_credentials=None,
+            insecure=False,
+            compression=None,
+            wait_for_ready=None,
+            timeout=None,
+            metadata=None):
+        return grpc.experimental.unary_stream(
+            request,
+            target,
+            '/metadata.MetadataService/WatchClusterState',
+            replica_dot_replication__pb2.Empty.SerializeToString,
+            replica_dot_metadata__pb2.ClusterState.FromString,
             options,
             channel_credentials,
             insecure,

--- a/replication.py
+++ b/replication.py
@@ -21,7 +21,7 @@ from concurrent import futures
 
 from replica.grpc_server import run_server
 from replica.client import GRPCReplicaClient, GRPCRouterClient
-from replica import metadata_pb2, metadata_pb2_grpc
+from replica import metadata_pb2, metadata_pb2_grpc, replication_pb2
 import grpc
 from router_server import run_router
 from metadata_service import run_metadata_service
@@ -275,9 +275,10 @@ class NodeCluster:
             self.update_partition_map()
 
         if start_router:
+            raddr = self.registry_addr if self.use_registry else None
             self.router_process = multiprocessing.Process(
                 target=run_router,
-                args=(self, "localhost", router_port),
+                args=(self, "localhost", router_port, raddr),
                 daemon=True,
             )
             self.router_process.start()

--- a/router_server.py
+++ b/router_server.py
@@ -1,22 +1,59 @@
 import grpc
 from concurrent import futures
+import threading
+import time
 
 from replica import replication_pb2, replication_pb2_grpc
-from replica import router_pb2_grpc
+from replica import router_pb2_grpc, metadata_pb2, metadata_pb2_grpc
 from replica.client import GRPCReplicaClient
 
 
 class RouterService(router_pb2_grpc.RouterServicer):
     """gRPC service forwarding requests to the correct partition owner."""
 
-    def __init__(self, cluster):
+    def __init__(self, cluster, registry_host=None, registry_port=None):
         self.cluster = cluster
         self.partition_map = cluster.get_partition_map()
         self.clients_by_id = {nid: node.client for nid, node in cluster.nodes_by_id.items()}
         self.server = None
+        self.registry_host = registry_host
+        self.registry_port = registry_port
+        self._registry_channel = None
+        self._registry_stub = None
+        self._watch_stop = threading.Event()
+        self._watch_thread = None
+        if registry_host and registry_port:
+            self._registry_channel = grpc.insecure_channel(f"{registry_host}:{registry_port}")
+            self._registry_stub = metadata_pb2_grpc.MetadataServiceStub(self._registry_channel)
+            try:
+                state = self._registry_stub.GetClusterState(replication_pb2.Empty())
+                self.update_partition_map(state.partition_map.items)
+            except Exception:
+                pass
+            self._start_watch_thread()
 
     def update_partition_map(self, mapping):
         self.partition_map = dict(mapping or {})
+
+    def _watch_loop(self):
+        if not self._registry_stub:
+            return
+        while not self._watch_stop.is_set():
+            try:
+                stream = self._registry_stub.WatchClusterState(replication_pb2.Empty())
+                for state in stream:
+                    self.update_partition_map(state.partition_map.items)
+                    if self._watch_stop.is_set():
+                        break
+            except Exception:
+                time.sleep(1.0)
+
+    def _start_watch_thread(self):
+        if self._watch_thread and self._watch_thread.is_alive():
+            return
+        t = threading.Thread(target=self._watch_loop, daemon=True)
+        self._watch_thread = t
+        t.start()
 
     # internal -----------------------------------------------------------
     def _split_key(self, key: str):
@@ -59,10 +96,14 @@ class RouterService(router_pb2_grpc.RouterServicer):
         return replication_pb2.Empty()
 
 
-def run_router(cluster, host="localhost", port=7000):
+def run_router(cluster, host="localhost", port=7000, registry_addr=None):
     """Launch a RouterService for ``cluster`` on the given ``host``/``port``."""
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-    service = RouterService(cluster)
+    if registry_addr:
+        rh, rp = registry_addr
+    else:
+        rh = rp = None
+    service = RouterService(cluster, registry_host=rh, registry_port=rp)
     router_pb2_grpc.add_RouterServicer_to_server(service, server)
     server.add_insecure_port(f"{host}:{port}")
     service.server = server

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import tempfile
+import time
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import grpc
+from replication import NodeCluster
+from driver import Driver
+from replica import metadata_pb2_grpc, replication_pb2
+
+
+class RegistryIntegrationTest(unittest.TestCase):
+    def test_registry_updates_router_and_driver(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cluster = NodeCluster(
+                base_path=tmpdir,
+                num_nodes=2,
+                key_ranges=[("a", "m"), ("m", "z")],
+                start_router=True,
+                use_registry=True,
+            )
+            try:
+                time.sleep(0.5)
+                channel = grpc.insecure_channel("localhost:9100")
+                stub = metadata_pb2_grpc.MetadataServiceStub(channel)
+                state = stub.GetClusterState(replication_pb2.Empty())
+                self.assertEqual(len(state.nodes), 2)
+
+                driver = Driver(cluster, registry_host="localhost", registry_port=9100)
+                time.sleep(0.5)
+                cluster.put(0, "ga", "v1")
+                time.sleep(0.5)
+                self.assertEqual(driver.get("u1", "ga"), "v1")
+
+                cluster.split_partition(0, "g")
+                new_map = cluster.update_partition_map()
+                time.sleep(1.0)
+
+                key2 = "ha"
+                pid2 = cluster.get_partition_id(key2)
+                owner2 = new_map[pid2]
+                cluster.router_client.put(key2, "v2", node_id=owner2)
+                time.sleep(0.5)
+                recs2 = cluster.router_client.get(key2)
+                self.assertTrue(recs2 and recs2[0][0] == "v2")
+            finally:
+                cluster.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend metadata.proto with `WatchClusterState` streaming RPC
- broadcast cluster updates from `MetadataService`
- watch registry state in nodes, driver and router
- allow router process to accept registry address
- create integration test for registry-based routing

## Testing
- `pytest tests/test_registry.py -q`
- `pytest -q` *(fails: KeyboardInterrupt after completing tests)*

------
https://chatgpt.com/codex/tasks/task_e_685d31ce86dc8331abf067ebcbea251c