### PR TITLE
Refactor FastAPI to use replication cluster

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,15 +1,37 @@
 from fastapi import FastAPI
-from database.lsm.lsm_db import SimpleLSMDB
+from database.replication import NodeCluster
 
 app = FastAPI()
 
-db = SimpleLSMDB(db_path="/tmp/api_db")
+
+@app.on_event("startup")
+def startup_event() -> None:
+    """Initialize the cluster when the API starts."""
+    app.state.cluster = NodeCluster(base_path="/tmp/api_cluster", num_nodes=3)
+
+
+@app.on_event("shutdown")
+def shutdown_event() -> None:
+    """Shutdown the cluster when the API stops."""
+    cluster = getattr(app.state, "cluster", None)
+    if cluster is not None:
+        cluster.shutdown()
 
 @app.get("/get/{key}")
 def get_value(key: str):
-    return {"value": db.get(key)}
+    """Retrieve a value from the cluster."""
+    value = app.state.cluster.get(0, key)
+    return {"value": value}
 
 @app.post("/put/{key}")
 def put_value(key: str, value: str):
-    db.put(key, value)
+    """Store ``value`` in the cluster under ``key``."""
+    app.state.cluster.put(0, key, value)
     return {"status": "ok"}
+
+
+@app.get("/health")
+def health() -> dict:
+    """Return basic cluster information."""
+    cluster = app.state.cluster
+    return {"nodes": len(cluster.nodes)}


### PR DESCRIPTION
## Summary
- initialize a NodeCluster on startup
- expose shutdown hook for the cluster
- use cluster for get/put operations
- add a health endpoint for cluster status

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_partition_api.py::HashPartitionAPITest::test_partition_keys_map_to_different_nodes -q`

------
https://chatgpt.com/codex/tasks/task_e_6863fcde15648331b43a3ea5fcc646a6