### PR TITLE
Add basic API health endpoint test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ grpcio-health-checking
 protobuf<7.0.0,>=6.30.0
 fastapi
 uvicorn
+httpx<0.25

--- a/tests/api/test_api_init.py
+++ b/tests/api/test_api_init.py
@@ -1,0 +1,13 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+
+
+def test_api_starts_cluster_successfully():
+    with TestClient(app) as client:
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["nodes"] > 0


### PR DESCRIPTION
## Summary
- test that FastAPI instance boots cluster and reports node count
- pin httpx<0.25 for TestClient compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68640a7843dc83319d784ca5d8d2ed06