### PR TITLE
Update README with FastAPI server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,16 @@ sequenceDiagram
    ```
    The script creates a local cluster with multiple nodes and replicates operations between them.
 
+### FastAPI server
+
+`main.py` runs a small FastAPI application. Launch it with
+
+```bash
+python main.py
+# or: uvicorn api.main:app --reload
+```
+This automatically starts a `NodeCluster` during the startup event so the HTTP endpoints are backed by a live cluster.
+
 For per-user consistency use the `Driver`:
 
 ```python


### PR DESCRIPTION
## Summary
- document how to run the FastAPI server
- note that it starts a NodeCluster on startup

## Testing
- `python -m unittest tests/test_quorum.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68641150d57483319e1f521a30e41309