### PR TITLE
Add uvicorn entrypoint for API module

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ sequenceDiagram
 
 ```bash
 python main.py
+# or: python -m api.main
 # or: uvicorn api.main:app --reload
 ```
 This automatically starts a `NodeCluster` during the startup event so the HTTP endpoints are backed by a live cluster.

--- a/api/main.py
+++ b/api/main.py
@@ -35,3 +35,8 @@ def health() -> dict:
     """Return basic cluster information."""
     cluster = app.state.cluster
     return {"nodes": len(cluster.nodes)}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("api.main:app", host="0.0.0.0", port=8000, reload=False)


### PR DESCRIPTION
## Summary
- start FastAPI when running `api.main` as a module
- document module invocation in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest -v`

------
https://chatgpt.com/codex/tasks/task_e_68641536ed80833199065893d066b58e