### PR TITLE
Add cluster info API endpoints

### DIFF
--- a/tests/api/test_api_init.py
+++ b/tests/api/test_api_init.py
@@ -10,4 +10,6 @@ def test_api_starts_cluster_successfully():
     with TestClient(app) as client:
         resp = client.get("/health")
         assert resp.status_code == 200
-        assert resp.json()["nodes"] > 0
+        data = resp.json()
+        assert data["nodes"] > 0
+        assert data.get("healthy", 0) > 0

--- a/tests/api/test_cluster_endpoints.py
+++ b/tests/api/test_cluster_endpoints.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+
+
+def test_cluster_nodes():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/nodes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "nodes" in data
+        assert len(data["nodes"]) == 3
+        for node in data["nodes"]:
+            assert "node_id" in node
+            assert "port" in node
+
+
+def test_cluster_partitions():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/partitions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "partitions" in data
+        assert len(data["partitions"]) > 0
+        ids = [p["id"] for p in data["partitions"]]
+        assert ids == sorted(ids)
+
+
+def test_time_series_metrics():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/metrics/time_series")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "latency_ms" in data
+        assert isinstance(data["latency_ms"], list)
+        assert "throughput" in data
+
+
+def test_cluster_config():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["replication_factor"] >= 1
+        assert data["num_partitions"] >= 1


### PR DESCRIPTION
## Summary
- extend API server with new cluster routes
- add helper to list nodes using `GetNodeInfo`
- expose partition and metric information
- return config details and improved health status
- add tests for new API endpoints

## Testing
- `python -m pytest tests/api/test_cluster_endpoints.py -q`
- `python -m pytest -q` *(all tests: 91 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_686429c256b48331a3093697daf59913