### PR TITLE
Implement node resource info helper

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -525,6 +525,10 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             keys = self._node.query_index(request.field, value)
         return replication_pb2.KeyList(keys=keys)
 
+    def GetNodeInfo(self, request, context):
+        """Return information about this node."""
+        return self._node.get_node_info()
+
 
 class HeartbeatService(replication_pb2_grpc.HeartbeatServiceServicer):
     """Simple heartbeat service used for peer liveness checks."""
@@ -572,6 +576,7 @@ class NodeServer:
     ):
         self.db_path = db_path
         self.db = SimpleLSMDB(db_path=db_path)
+        self.start_time = time.time()
         self.host = host
         self.port = port
         self.node_id = node_id
@@ -860,6 +865,35 @@ class NodeServer:
             ts,
             op_id=op_id,
             vector=vc.clock,
+        )
+
+    def get_node_info(self):
+        """Return runtime statistics for this node."""
+
+        # Actual resource monitoring may require the ``psutil`` package.
+        log_file = self._replication_log_file()
+        hints_file = self._hints_file()
+        log_size = os.path.getsize(log_file) if os.path.exists(log_file) else 0
+        hints_size = os.path.getsize(hints_file) if os.path.exists(hints_file) else 0
+        try:
+            import psutil  # type: ignore
+
+            cpu = psutil.cpu_percent(interval=None)
+            memory = psutil.virtual_memory().percent
+            disk = psutil.disk_usage(self.db_path).percent
+        except Exception:
+            cpu = memory = disk = 0.0
+
+        uptime = time.time() - self.start_time
+        return replication_pb2.NodeInfoResponse(
+            node_id=self.node_id,
+            status="running",
+            cpu=cpu,
+            memory=memory,
+            disk=disk,
+            uptime=int(uptime),
+            replication_log_size=log_size,
+            hints_count=hints_size,
         )
 
     def cleanup_replication_log(self) -> None:


### PR DESCRIPTION
## Summary
- track start time in `NodeServer`
- provide a `get_node_info` method returning runtime metrics
- expose `GetNodeInfo` RPC via `ReplicaService`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686443a6daa48331bd60348252ae9683