### PR TITLE
Add RPC and API endpoint tests

### DIFF
--- a/tests/api/test_dashboard_api.py
+++ b/tests/api/test_dashboard_api.py
@@ -1,0 +1,43 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+
+
+def test_dashboard_nodes():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/nodes")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "nodes" in data
+        assert isinstance(data["nodes"], list)
+        assert len(data["nodes"]) > 0
+
+
+def test_dashboard_partitions():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/partitions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "partitions" in data
+        assert isinstance(data["partitions"], list)
+
+
+def test_dashboard_time_series():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/metrics/time_series")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "latency_ms" in data
+        assert "throughput" in data
+
+
+def test_dashboard_config():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "replication_factor" in data
+        assert "num_partitions" in data


### PR DESCRIPTION
## Summary
- implement `GetNodeInfo` RPC on ReplicaService
- expose node start time and return metrics
- test the new RPC via gRPC client
- add dashboard API tests covering basic endpoints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864439e1bbc83319e0a4a379a7fb16e