### PR TITLE
Implement replication status RPC

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -529,6 +529,10 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
         """Return information about this node."""
         return self._node.get_node_info()
 
+    def GetReplicationStatus(self, request, context):
+        """Return replication metadata like last seen sequences and hints."""
+        return self._node.get_replication_status()
+
 class HeartbeatService(replication_pb2_grpc.HeartbeatServiceServicer):
     """Simple heartbeat service used for peer liveness checks."""
 
@@ -894,6 +898,15 @@ class NodeServer:
             uptime=int(uptime),
             replication_log_size=log_size,
             hints_count=hints_size,
+        )
+
+    def get_replication_status(self):
+        """Return last seen sequence numbers and hint counts."""
+
+        hints_count = {peer: len(ops) for peer, ops in self.hints.items()}
+        return replication_pb2.ReplicationStatusResponse(
+            last_seen={peer: int(seq) for peer, seq in self.last_seen.items()},
+            hints=hints_count,
         )
 
     def cleanup_replication_log(self) -> None:

--- a/tests/test_replica_service.py
+++ b/tests/test_replica_service.py
@@ -196,5 +196,23 @@ class NodeInfoRPCTest(unittest.TestCase):
                 node.db.close()
 
 
+class ReplicationStatusRPCTest(unittest.TestCase):
+    def test_get_replication_status_rpc(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, port=9100, node_id="A", peers=[])
+            node.server.start()
+            try:
+                channel = grpc.insecure_channel(f"{node.host}:{node.port}")
+                stub = replication_pb2_grpc.ReplicaStub(channel)
+                req = replication_pb2.NodeInfoRequest(node_id="A")
+                resp = stub.GetReplicationStatus(req)
+                self.assertEqual(dict(resp.last_seen), {})
+                self.assertEqual(dict(resp.hints), {})
+                channel.close()
+            finally:
+                node.server.stop(0).wait()
+                node.db.close()
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- implement `get_replication_status` in `NodeServer`
- expose RPC `GetReplicationStatus` via `ReplicaService`
- test replication status RPC

## Testing
- `pytest tests/test_replica_service.py::ReplicationStatusRPCTest::test_get_replication_status_rpc -q`

------
https://chatgpt.com/codex/tasks/task_e_686455e3a2e88331b3a35143f4312709