### PR TITLE
Add fetch-based DB service

### DIFF
--- a/app/components/DataBrowser.tsx
+++ b/app/components/DataBrowser.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import * as dbService from '../services/mock';
+import * as dbService from '../services/mockDatabaseService';
 import { UserRecord } from '../types';
 import DataTable from './databrowser/DataTable';
 import DataEditorModal from './databrowser/DataEditorModal';

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -1,2 +1,3 @@
 export * as api from './api';
 export * as mock from './mock';
+export * as db from './mockDatabaseService';

--- a/app/services/mockDatabaseService.ts
+++ b/app/services/mockDatabaseService.ts
@@ -1,0 +1,48 @@
+import { UserRecord } from '../types';
+
+const API_BASE = 'http://localhost:8000';
+
+const fetchJson = async <T>(path: string, options?: RequestInit): Promise<T> => {
+  const resp = await fetch(`${API_BASE}${path}`, options);
+  if (!resp.ok) {
+    throw new Error(`Request failed: ${resp.status}`);
+  }
+  if (resp.headers.get('content-length') === '0' || resp.status === 204) {
+    return {} as T;
+  }
+  return resp.json() as Promise<T>;
+};
+
+export const getUserRecords = async (): Promise<UserRecord[]> => {
+  const data = await fetchJson<{ records: { partition_key: string; clustering_key: string; value: string }[] }>('/data/records');
+  return data.records.map(r => ({
+    partitionKey: r.partition_key,
+    clusteringKey: r.clustering_key,
+    value: r.value,
+  }));
+};
+
+export const saveUserRecord = async (record: UserRecord): Promise<UserRecord> => {
+  const path = `/data/records/${encodeURIComponent(record.partitionKey)}/${encodeURIComponent(record.clusteringKey)}?value=${encodeURIComponent(record.value)}`;
+  await fetchJson<{ status: string }>(path, { method: 'PUT' });
+  return record;
+};
+
+export const deleteUserRecord = async (partitionKey: string, clusteringKey: string): Promise<void> => {
+  const path = `/data/records/${encodeURIComponent(partitionKey)}/${encodeURIComponent(clusteringKey)}`;
+  await fetchJson<{ status: string }>(path, { method: 'DELETE' });
+};
+
+export const scanRange = async (
+  partitionKey: string,
+  startCk: string,
+  endCk: string,
+): Promise<UserRecord[]> => {
+  const params = new URLSearchParams({ partition_key: partitionKey, start_ck: startCk, end_ck: endCk });
+  const data = await fetchJson<{ items: { clustering_key: string; value: string }[] }>(`/data/records/scan_range?${params.toString()}`);
+  return data.items.map(i => ({
+    partitionKey,
+    clusteringKey: i.clustering_key,
+    value: i.value,
+  }));
+};


### PR DESCRIPTION
## Summary
- implement a new database service `mockDatabaseService.ts` using fetch
- switch DataBrowser to use the new service
- export database service in `services/index`

## Testing
- `npx vitest run --silent`
- `pytest -k test_data_records_api.py -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_68647db33d3c83319c985fc67e5628d6