### PR TITLE
Add internals api tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ replica/replication_pb2_grpc.py
 .env
 *.db
 
+
+# Frontend dependencies
+app/node_modules/
+

--- a/tests/api/test_internals_api.py
+++ b/tests/api/test_internals_api.py
@@ -6,7 +6,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from api.main import app
 
 
-def test_cluster_hotspots_endpoint():
+def test_cluster_hotspots():
     with TestClient(app) as client:
         # generate some traffic
         client.post("/put/hotkey", params={"value": "1"})
@@ -20,10 +20,15 @@ def test_cluster_hotspots_endpoint():
         assert isinstance(data["hot_keys"], list)
 
 
-def test_node_replication_status_endpoint():
+def test_replication_status():
     with TestClient(app) as client:
-        resp = client.get("/nodes/node_0/replication_status")
+        nodes_resp = client.get("/cluster/nodes")
+        assert nodes_resp.status_code == 200
+        node_id = nodes_resp.json()["nodes"][0]["node_id"]
+
+        resp = client.get(f"/nodes/{node_id}/replication_status")
         assert resp.status_code == 200
         data = resp.json()
         assert "last_seen" in data
         assert "hints" in data
+


### PR DESCRIPTION
## Summary
- cover cluster hotspots and replication status APIs
- ignore frontend node dependencies
- include newline cleanup for linting

## Testing
- `npm test --prefix app`
- `pytest tests/api/test_internals_api.py::test_cluster_hotspots tests/api/test_internals_api.py::test_replication_status tests/test_replica_service.py::ReplicationStatusRPCTest::test_get_replication_status_rpc -q`


------
https://chatgpt.com/codex/tasks/task_e_68645fe3eea88331af150941626dd0ff