### PR TITLE
Add management endpoints and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ python main.py
 ```
 This automatically starts a `NodeCluster` during the startup event so the HTTP endpoints are backed by a live cluster.
 
+Management actions are available under the `/cluster/actions` prefix:
+
+* `POST /cluster/actions/check_hot_partitions` – split hot partitions based on metrics
+* `POST /cluster/actions/reset_metrics` – reset access counters
+* `POST /cluster/actions/mark_hot_key` – salt and optionally migrate a specific key
+* `POST /cluster/actions/rebalance` – propagate the current partition map to all nodes
+
 For per-user consistency use the `Driver`:
 
 ```python

--- a/api/main.py
+++ b/api/main.py
@@ -163,6 +163,38 @@ def cluster_config() -> dict:
     }
 
 
+@app.post("/cluster/actions/check_hot_partitions")
+def check_hot_partitions(threshold: float = 2.0, min_keys: int = 2) -> dict:
+    """Split hot partitions based on access metrics."""
+    cluster = app.state.cluster
+    cluster.check_hot_partitions(threshold=threshold, min_keys=min_keys)
+    return {"status": "ok"}
+
+
+@app.post("/cluster/actions/reset_metrics")
+def reset_metrics() -> dict:
+    """Reset access frequency metrics for partitions and keys."""
+    cluster = app.state.cluster
+    cluster.reset_metrics()
+    return {"status": "ok"}
+
+
+@app.post("/cluster/actions/mark_hot_key")
+def mark_hot_key(key: str, buckets: int, migrate: bool = False) -> dict:
+    """Start salting ``key`` using ``buckets`` buckets."""
+    cluster = app.state.cluster
+    cluster.mark_hot_key(key, buckets, migrate=migrate)
+    return {"status": "ok"}
+
+
+@app.post("/cluster/actions/rebalance")
+def rebalance() -> dict:
+    """Propagate the current partition map to all nodes."""
+    cluster = app.state.cluster
+    cluster.update_partition_map()
+    return {"status": "ok"}
+
+
 @app.get("/nodes/{node_id}/replication_status")
 def node_replication_status(node_id: str) -> dict:
     """Return replication status information for ``node_id``."""


### PR DESCRIPTION
## Summary
- expose cluster management actions via FastAPI
- document new action endpoints in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864938257e48331aeb28b9fc4079282