### PR TITLE
Add secondary index query endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -247,6 +247,14 @@ def scan_range(
     return {"items": items}
 
 
+@app.get("/data/query_index")
+def query_index(field: str, value: str) -> dict:
+    """Return keys matching ``field``/``value`` from secondary indexes."""
+    cluster = app.state.cluster
+    keys = cluster.secondary_query(field, value)
+    return {"keys": keys}
+
+
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run("api.main:app", host="0.0.0.0", port=8000, reload=False)

--- a/tests/api/test_data_api.py
+++ b/tests/api/test_data_api.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import tempfile
+import json
+import time
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+from database.replication import NodeCluster
+
+
+def test_query_index_endpoint():
+    with TestClient(app) as client:
+        old_cluster = app.state.cluster
+        tmpdir = tempfile.mkdtemp()
+        old_cluster.shutdown()
+        app.state.cluster = NodeCluster(base_path=tmpdir, num_nodes=2, index_fields=["color"])
+
+        data = {"partitionKey": "p1", "value": json.dumps({"color": "red"})}
+        resp = client.post("/data/records", json=data)
+        assert resp.status_code == 200
+
+        time.sleep(0.5)
+        resp = client.get("/data/query_index", params={"field": "color", "value": "red"})
+        assert resp.status_code == 200
+        result = resp.json()
+        assert result.get("keys") == ["p1"]


### PR DESCRIPTION
## Summary
- expose a `/data/query_index` endpoint
- test index query using `TestClient`

## Testing
- `pytest tests/api -q`
- `pytest -q` *(interrupted after partial run)*

------
https://chatgpt.com/codex/tasks/task_e_686494bcb1308331893b7a8c63c54a49