### PR TITLE
Add node management API functions

### DIFF
--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -1,3 +1,4 @@
 export * as api from './api';
 export * as mock from './mock';
 export * as db from './mockDatabaseService';
+export { addNode, removeNode, stopNode, startNode } from './api';


### PR DESCRIPTION
## Summary
- support POST/DELETE fetch options in `fetchJson`
- add node management helpers in `api.ts`
- re-export helpers from service index

## Testing
- `pytest -q` *(fails: tests/test_lsm_db.py::SimpleLSMDBTest::test_delete_and_compaction)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864963596548331937251d65f4044fd