### PR TITLE
Add API test for query_index

### DIFF
--- a/tests/api/test_data_api.py
+++ b/tests/api/test_data_api.py
@@ -17,8 +17,10 @@ def test_query_index_endpoint():
         old_cluster.shutdown()
         app.state.cluster = NodeCluster(base_path=tmpdir, num_nodes=2, index_fields=["color"])
 
-        data = {"partitionKey": "p1", "value": json.dumps({"color": "red"})}
-        resp = client.post("/data/records", json=data)
+        resp = client.post(
+            "/put/p1",
+            params={"value": json.dumps({"color": "red"})},
+        )
         assert resp.status_code == 200
 
         time.sleep(0.5)


### PR DESCRIPTION
## Summary
- modify `tests/api/test_data_api.py` to populate data through `/put` and query `/data/query_index`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651d09169c8331b4189e94ae35ccfd