### PR TITLE
Add REST index query docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The REST server offers simple endpoints to manage data stored in the cluster.
 | `PUT` | `/data/records/{partition_key}/{clustering_key}` | Update an existing record (send `value` as query param) |
 | `DELETE` | `/data/records/{partition_key}/{clustering_key}` | Remove a record |
 | `GET` | `/data/records/scan_range` | Retrieve items for a partition between two clustering keys |
+| `GET` | `/data/query_index` | Retrieve keys from a secondary index |
 
 Example usage with `curl`:
 
@@ -168,6 +169,9 @@ curl http://localhost:8000/data/records
 curl -X PUT "http://localhost:8000/data/records/alpha/a?value=v2"
 
 curl -X DELETE http://localhost:8000/data/records/alpha/a
+
+curl "http://localhost:8000/data/query_index?field=color&value=red"
+# {"keys": ["p1"]}
 ```
 
 ### Topology aware driver

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -825,6 +825,15 @@ python -m unittest tests/test_smart_driver.py -v
 Esse comando deve ser executado sempre que novas funcionalidades forem
 implementadas ou arquivos forem modificados.
 
+### Consulta de índice via API
+
+Para recuperar as chaves de um valor indexado pela API HTTP:
+
+```bash
+curl "http://localhost:8000/data/query_index?field=color&value=red"
+# {"keys": ["p1"]}
+```
+
 ## Estrutura de arquivos
 
 - `main.py` – exemplo de inicialização do cluster.


### PR DESCRIPTION
## Summary
- document `/data/query_index` REST endpoint in README
- include example usage for querying indexes
- mirror the info in Portuguese docs

## Testing
- `python -m pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68651d099fe08331bd5eb314e69efa30