### PR TITLE
Add docs for cluster action routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ curl -X PUT "http://localhost:8000/data/records/alpha/a?value=v2"
 curl -X DELETE http://localhost:8000/data/records/alpha/a
 ```
 
+### Cluster actions API
+
+The API also exposes maintenance operations to manage the cluster:
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `POST` | `/cluster/actions/check_hot_partitions` | Split partitions with heavy traffic |
+| `POST` | `/cluster/actions/reset_metrics` | Reset hotspot counters |
+| `POST` | `/cluster/actions/mark_hot_key` | Enable salting for a hot key |
+| `POST` | `/cluster/actions/rebalance` | Evenly redistribute partitions |
+
+Example:
+
+```bash
+curl -X POST "http://localhost:8000/cluster/actions/reset_metrics"
+curl -X POST "http://localhost:8000/cluster/actions/check_hot_partitions"
+curl -X POST "http://localhost:8000/cluster/actions/mark_hot_key?key=hot&buckets=4"
+curl -X POST "http://localhost:8000/cluster/actions/rebalance"
+```
+
 ### Topology aware driver
 
 The driver keeps a local cache of the partition map obtained with `get_partition_map()`. Requests go directly to the responsible node. If a `NotOwner` error is returned (for example after a partition migration) the driver refreshes the cache and retries.

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -587,6 +587,26 @@ print(cluster.get_hot_partitions())
 print(cluster.get_hot_keys())
 ```
 
+### Ações de cluster via API
+
+A API HTTP também oferece rotas para manutenção do cluster:
+
+| Método | Caminho | Descrição |
+| ------ | ------- | --------- |
+| `POST` | `/cluster/actions/check_hot_partitions` | Divide partições muito movimentadas |
+| `POST` | `/cluster/actions/reset_metrics` | Zera os contadores de hotspot |
+| `POST` | `/cluster/actions/mark_hot_key` | Ativa salting para uma chave quente |
+| `POST` | `/cluster/actions/rebalance` | Redistribui partições entre os nós |
+
+Exemplo de uso:
+
+```bash
+curl -X POST http://localhost:8000/cluster/actions/reset_metrics
+curl -X POST http://localhost:8000/cluster/actions/check_hot_partitions
+curl -X POST "http://localhost:8000/cluster/actions/mark_hot_key?key=hot&buckets=4"
+curl -X POST http://localhost:8000/cluster/actions/rebalance
+```
+
 ## Balanceamento de leituras
 
 Para distribuir consultas entre as réplicas defina `load_balance_reads=True`


### PR DESCRIPTION
## Summary
- describe cluster management API endpoints in README
- add Portuguese translation for cluster action routes

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68651da90ef88331b7d66ed042a23cb6