### PR TITLE
Add hotspot API tests

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -177,6 +177,29 @@ def remove_node(node_id: str) -> dict:
     return {"status": "ok"}
 
 
+@app.post("/cluster/actions/check_hot_partitions")
+def check_hot_partitions(threshold: float = 2.0, min_keys: int = 2) -> dict:
+    """Check for hot partitions and split them if needed."""
+    cluster = app.state.cluster
+    cluster.check_hot_partitions(threshold=threshold, min_keys=min_keys)
+    return {"status": "ok"}
+
+
+@app.post("/cluster/actions/reset_metrics")
+def reset_metrics() -> dict:
+    """Reset partition and key frequency metrics."""
+    app.state.cluster.reset_metrics()
+    return {"status": "ok"}
+
+
+@app.post("/cluster/actions/mark_hot_key")
+def mark_hot_key(key: str, buckets: int, migrate: bool = False) -> dict:
+    """Enable salting for ``key`` using ``buckets`` variants."""
+    cluster = app.state.cluster
+    cluster.mark_hot_key(key, buckets=buckets, migrate=migrate)
+    return {"status": "ok"}
+
+
 @app.post("/nodes/{node_id}/stop")
 def stop_node(node_id: str) -> dict:
     """Stop the node identified by ``node_id``."""

--- a/tests/api/test_hotspot_api.py
+++ b/tests/api/test_hotspot_api.py
@@ -1,0 +1,54 @@
+import os
+import sys
+import time
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+
+
+def test_check_hot_partitions_splits_partition():
+    with TestClient(app) as client:
+        cluster = app.state.cluster
+        from database.clustering.partitioning import HashPartitioner
+
+        # convert existing cluster to hash partitioning for easier splitting
+        cluster.partitioner = HashPartitioner(cluster.num_partitions, cluster.nodes)
+        cluster.partition_strategy = "hash"
+        cluster.ring = None
+        cluster.key_ranges = None
+        cluster.update_partition_map()
+        cluster.reset_metrics()
+        time.sleep(0.2)
+        initial = cluster.num_partitions
+        for i in range(5):
+            client.post("/put/b", params={"value": str(i)})
+            client.post("/put/ae", params={"value": str(i)})
+        resp = client.post(
+            "/cluster/actions/check_hot_partitions",
+            params={"threshold": 1.0, "min_keys": 2},
+        )
+        assert resp.status_code == 200
+        assert cluster.num_partitions > initial
+
+
+def test_reset_metrics_clears_partition_ops():
+    with TestClient(app) as client:
+        cluster = app.state.cluster
+        for i in range(3):
+            client.post("/put/x", params={"value": str(i)})
+        assert any(o > 0 for o in cluster.partition_ops)
+        resp = client.post("/cluster/actions/reset_metrics")
+        assert resp.status_code == 200
+        assert all(o == 0 for o in cluster.partition_ops)
+
+
+def test_mark_hot_key_endpoint():
+    with TestClient(app) as client:
+        cluster = app.state.cluster
+        resp = client.post(
+            "/cluster/actions/mark_hot_key",
+            params={"key": "hk", "buckets": 2, "migrate": False},
+        )
+        assert resp.status_code == 200
+        assert "hk" in cluster.salted_keys


### PR DESCRIPTION
## Summary
- expose hot partition and key management endpoints
- test hotspot endpoints via FastAPI client

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68651d6276648331963cd028a3cfe366