### PR TITLE
Implement rebalance API endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -200,6 +200,14 @@ def mark_hot_key(key: str, buckets: int, migrate: bool = False) -> dict:
     return {"status": "ok"}
 
 
+@app.post("/cluster/actions/rebalance")
+def rebalance() -> dict:
+    """Re-send the current partition map to all nodes."""
+    cluster = app.state.cluster
+    cluster.update_partition_map()
+    return {"status": "ok"}
+
+
 @app.post("/nodes/{node_id}/stop")
 def stop_node(node_id: str) -> dict:
     """Stop the node identified by ``node_id``."""


### PR DESCRIPTION
## Summary
- extend API with `/cluster/actions/rebalance`
- use `app.state.cluster.update_partition_map()` to rebalance

## Testing
- `pytest -q tests/api`


------
https://chatgpt.com/codex/tasks/task_e_6865278d36d88331b60b4fb1128e66e1