### PR TITLE
Implement hotspot management endpoints in UI

### DIFF
--- a/app/components/internals/HotspotsView.tsx
+++ b/app/components/internals/HotspotsView.tsx
@@ -1,17 +1,34 @@
 import React, { useState, useEffect } from 'react';
-import { getHotspots } from '../../services/api';
+import { getHotspots, checkHotPartitions } from '../../services/api';
 import { HotspotInfo } from '../../types';
 import Card from '../common/Card';
+import Button from '../common/Button';
 
 const HotspotsView: React.FC = () => {
     const [hotspots, setHotspots] = useState<HotspotInfo | null>(null);
     const [isLoading, setIsLoading] = useState(true);
 
+    const fetchData = async () => {
+        const data = await getHotspots();
+        setHotspots(data);
+    };
+
+    const handleCheck = async () => {
+        setIsLoading(true);
+        try {
+            await checkHotPartitions();
+            await fetchData();
+        } catch (error) {
+            console.error("Failed to check hot partitions:", error);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     useEffect(() => {
         const fetchHotspots = async () => {
             try {
-                const data = await getHotspots();
-                setHotspots(data);
+                await fetchData();
             } catch (error) {
                 console.error("Failed to fetch hotspot data:", error);
             } finally {
@@ -32,9 +49,12 @@ const HotspotsView: React.FC = () => {
     return (
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <Card className="overflow-x-auto">
-                <div className="p-4 border-b border-green-800/60">
-                    <h3 className="text-lg font-semibold text-green-100">Hot Partitions</h3>
-                    <p className="text-sm text-green-300">Partitions with the highest operational load.</p>
+                <div className="p-4 border-b border-green-800/60 flex items-center justify-between">
+                    <div>
+                        <h3 className="text-lg font-semibold text-green-100">Hot Partitions</h3>
+                        <p className="text-sm text-green-300">Partitions with the highest operational load.</p>
+                    </div>
+                    <Button size="sm" variant="secondary" onClick={handleCheck}>Check</Button>
                 </div>
                 <table className="w-full text-sm text-left text-green-300">
                     <thead className="text-xs text-green-400 uppercase bg-green-900/30">

--- a/app/components/management/ClusterActions.tsx
+++ b/app/components/management/ClusterActions.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button';
+import { rebalance, resetMetrics } from '../../services/api';
 
 interface ClusterActionsProps {
     onAddNode: () => void;
@@ -8,6 +9,21 @@ interface ClusterActionsProps {
 }
 
 const ClusterActions: React.FC<ClusterActionsProps> = ({ onAddNode, isLoading }) => {
+  const handleRebalance = async () => {
+    try {
+      await rebalance();
+    } catch (err) {
+      console.error('Failed to rebalance cluster:', err);
+    }
+  };
+
+  const handleResetMetrics = async () => {
+    try {
+      await resetMetrics();
+    } catch (err) {
+      console.error('Failed to reset metrics:', err);
+    }
+  };
   return (
     <Card className="p-6">
       <h3 className="text-xl font-semibold text-green-50 mb-4">Cluster Actions</h3>
@@ -29,8 +45,17 @@ const ClusterActions: React.FC<ClusterActionsProps> = ({ onAddNode, isLoading })
                 <h4 className="font-semibold text-green-100">Trigger Cluster Rebalance</h4>
                 <p className="text-sm text-green-400">Manually start a process to redistribute data evenly.</p>
             </div>
-            <Button onClick={() => alert("Rebalancing...")} variant="secondary">
+            <Button onClick={handleRebalance} variant="secondary">
                 Rebalance
+            </Button>
+        </div>
+        <div className="flex items-center justify-between p-4 bg-green-900/20 rounded-lg">
+            <div>
+                <h4 className="font-semibold text-green-100">Reset Metrics</h4>
+                <p className="text-sm text-green-400">Clear hotspot counters for partitions and keys.</p>
+            </div>
+            <Button onClick={handleResetMetrics} variant="secondary">
+                Reset Metrics
             </Button>
         </div>
       </div>

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -155,3 +155,34 @@ export const startNode = async (nodeId: string): Promise<Node> => {
   const node = nodes.find(n => n.id === nodeId)!;
   return node;
 };
+
+export const checkHotPartitions = async (): Promise<void> => {
+  await fetchJson<{ status: string }>('/cluster/actions/check_hot_partitions', {
+    method: 'POST',
+  });
+};
+
+export const resetMetrics = async (): Promise<void> => {
+  await fetchJson<{ status: string }>('/cluster/actions/reset_metrics', {
+    method: 'POST',
+  });
+};
+
+export const markHotKey = async (
+  key: string,
+  buckets: number,
+  migrate = false,
+): Promise<void> => {
+  const params = new URLSearchParams({ key, buckets: String(buckets) });
+  if (migrate) params.append('migrate', 'true');
+  await fetchJson<{ status: string }>(
+    `/cluster/actions/mark_hot_key?${params.toString()}`,
+    { method: 'POST' },
+  );
+};
+
+export const rebalance = async (): Promise<void> => {
+  await fetchJson<{ status: string }>('/cluster/actions/rebalance', {
+    method: 'POST',
+  });
+};


### PR DESCRIPTION
## Summary
- add API helpers for hot partitions, metrics reset, hot key marking and cluster rebalance
- add button in hotspots view to trigger checking of hot partitions
- extend cluster actions panel with Rebalance and Reset Metrics buttons

## Testing
- `npm run build`
- `pytest -q` *(fails: KeyboardInterrupt after ~40 tests)*

------
https://chatgpt.com/codex/tasks/task_e_686527cfac5c833192ebfa61bd1da3fc