### PR TITLE
Implement storage inspector API calls

### DIFF
--- a/app/components/management/StorageInspector.tsx
+++ b/app/components/management/StorageInspector.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { WALEntry, StorageEntry, SSTableInfo } from '../../types';
-import * as storageService from '../../services/storageService';
+import {
+    getWalEntries,
+    getMemtableEntries,
+    getSstables,
+} from '../../services/api';
 import Card from '../common/Card';
-import Button from '../common/Button';
 
 type StorageTab = 'wal' | 'memtable' | 'sstables';
 
@@ -32,7 +35,7 @@ const WALView: React.FC<{nodeId: string}> = ({ nodeId }) => {
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        storageService.getWalEntries(nodeId).then(data => {
+        getWalEntries(nodeId).then(data => {
             setEntries(data);
             setIsLoading(false);
         });
@@ -72,7 +75,7 @@ const MemTableView: React.FC<{nodeId: string}> = ({ nodeId }) => {
     const [isLoading, setIsLoading] = useState(true);
 
     useEffect(() => {
-        storageService.getMemtableEntries(nodeId).then(data => {
+        getMemtableEntries(nodeId).then(data => {
             setEntries(data);
             setIsLoading(false);
         });
@@ -109,7 +112,7 @@ const SSTablesView: React.FC<{nodeId: string}> = ({ nodeId }) => {
 
     useEffect(() => {
         setIsLoading(true);
-        storageService.getSstables(nodeId).then(data => {
+        getSstables(nodeId).then(data => {
             setTables(data);
             setIsLoading(false);
         });

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -1,4 +1,13 @@
 export * as api from './api';
 export * as storage from './storageService';
 export * as db from './databaseService';
-export { addNode, removeNode, stopNode, startNode } from './api';
+export {
+  addNode,
+  removeNode,
+  stopNode,
+  startNode,
+  getWalEntries,
+  getMemtableEntries,
+  getSstables,
+  getSstableEntries,
+} from './api';

--- a/app/services/storageService.ts
+++ b/app/services/storageService.ts
@@ -106,10 +106,10 @@ export const getClusterConfig = (): Promise<ClusterConfig> => api.getClusterConf
 export const getHotspots = (): Promise<HotspotInfo> => api.getHotspots();
 export const getReplicationStatus = (): Promise<ReplicationStatus[]> => api.getReplicationStatus();
 
-export const getWalEntries = (nodeId: string): Promise<WALEntry[]> => mockApi(MOCK_WAL_ENTRIES[nodeId] || []);
-export const getMemtableEntries = (nodeId: string): Promise<StorageEntry[]> => mockApi(MOCK_MEMTABLE_ENTRIES[nodeId] || []);
-export const getSstables = (nodeId: string): Promise<SSTableInfo[]> => mockApi(MOCK_SSTABLES[nodeId] || []);
-export const getSstableEntries = (nodeId: string, sstableId: string): Promise<StorageEntry[]> => mockApi(MOCK_SSTABLE_CONTENT[nodeId]?.[sstableId] || []);
+export const getWalEntries = (nodeId: string): Promise<WALEntry[]> => api.getWalEntries(nodeId);
+export const getMemtableEntries = (nodeId: string): Promise<StorageEntry[]> => api.getMemtableEntries(nodeId);
+export const getSstables = (nodeId: string): Promise<SSTableInfo[]> => api.getSstables(nodeId);
+export const getSstableEntries = (nodeId: string, sstableId: string): Promise<StorageEntry[]> => api.getSstableEntries(nodeId, sstableId);
 
 
 


### PR DESCRIPTION
## Summary
- extend API service for storage inspection
- re-export storage helpers from the service index
- refactor StorageInspector to use real API endpoints
- route storage service helper functions through the API

## Testing
- `pip install -r requirements.txt`
- `pytest -q tests/api/test_storage_api.py`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686528bfef2c8331a8e56b2aa2d9e0f4