### PR TITLE
Add partition management endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -200,6 +200,28 @@ def mark_hot_key(key: str, buckets: int, migrate: bool = False) -> dict:
     return {"status": "ok"}
 
 
+@app.post("/cluster/actions/split_partition")
+def split_partition(pid: int, split_key: str | None = None) -> dict:
+    """Split the partition ``pid`` at ``split_key`` if provided."""
+    cluster = app.state.cluster
+    try:
+        cluster.split_partition(pid, split_key)
+        return {"status": "ok"}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
+@app.post("/cluster/actions/merge_partitions")
+def merge_partitions(pid1: int, pid2: int) -> dict:
+    """Merge adjacent partitions ``pid1`` and ``pid2``."""
+    cluster = app.state.cluster
+    try:
+        cluster.merge_partitions(pid1, pid2)
+        return {"status": "ok"}
+    except Exception as exc:
+        return {"error": str(exc)}
+
+
 @app.post("/cluster/actions/rebalance")
 def rebalance() -> dict:
     """Re-send the current partition map to all nodes."""


### PR DESCRIPTION
## Summary
- expose `/cluster/actions/split_partition` and `/cluster/actions/merge_partitions`
- return error JSON if these actions fail

## Testing
- `pytest -q tests/api/test_cluster_actions.py tests/api/test_cluster_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_68652dc608548331b2778eae28d261e7