### PR TITLE
Add partition management UI

### DIFF
--- a/app/components/Management.tsx
+++ b/app/components/Management.tsx
@@ -5,6 +5,7 @@ import { Node } from '../types';
 import NodeSelector from './management/NodeSelector';
 import NodeDetail from './management/NodeDetail';
 import ClusterActions from './management/ClusterActions';
+import PartitionActions from './management/PartitionActions';
 
 interface ManagementProps {
   initialSelectedNodeId: string | null;
@@ -123,10 +124,10 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
             isActionLoading={isActionLoading}
           />
         </div>
-        <div className="flex-1">
+        <div className="flex-1 space-y-6">
           {selectedNode ? (
-            <NodeDetail 
-                node={selectedNode} 
+            <NodeDetail
+                node={selectedNode}
                 onRemove={handleRemoveNode}
                 onStop={handleStopNode}
                 onStart={handleStartNode}
@@ -135,6 +136,7 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
           ) : (
             <ClusterActions onAddNode={handleAddNode} isLoading={isActionLoading}/>
           )}
+          <PartitionActions />
         </div>
       </div>
     </div>

--- a/app/components/management/PartitionActions.tsx
+++ b/app/components/management/PartitionActions.tsx
@@ -1,0 +1,93 @@
+import React, { useState } from 'react';
+import Card from '../common/Card';
+import Button from '../common/Button';
+import { splitPartition, mergePartitions } from '../../services/api';
+
+const PartitionActions: React.FC = () => {
+  const [splitPid, setSplitPid] = useState('');
+  const [splitKey, setSplitKey] = useState('');
+  const [mergeLeft, setMergeLeft] = useState('');
+  const [mergeRight, setMergeRight] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSplit = async () => {
+    if (!splitPid) return;
+    setIsLoading(true);
+    try {
+      await splitPartition(Number(splitPid), splitKey || undefined);
+    } catch (err) {
+      console.error('Failed to split partition:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleMerge = async () => {
+    if (!mergeLeft || !mergeRight) return;
+    setIsLoading(true);
+    try {
+      await mergePartitions(Number(mergeLeft), Number(mergeRight));
+    } catch (err) {
+      console.error('Failed to merge partitions:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const inputClass =
+    'w-full bg-[#10180f] border border-green-700/50 rounded-md px-2 py-1 text-white placeholder-green-500 focus:outline-none focus:ring-2 focus:ring-green-500';
+
+  return (
+    <Card className="p-6">
+      <h3 className="text-xl font-semibold text-green-50 mb-4">Partition Actions</h3>
+      <div className="space-y-4">
+        <div className="space-y-2 p-4 bg-green-900/20 rounded-lg">
+          <h4 className="font-semibold text-green-100">Split Partition</h4>
+          <div className="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-2">
+            <input
+              type="number"
+              placeholder="Partition ID"
+              value={splitPid}
+              onChange={e => setSplitPid(e.target.value)}
+              className={inputClass}
+            />
+            <input
+              type="text"
+              placeholder="Split Key (optional)"
+              value={splitKey}
+              onChange={e => setSplitKey(e.target.value)}
+              className={inputClass}
+            />
+            <Button onClick={handleSplit} disabled={!splitPid || isLoading} size="sm">
+              Split
+            </Button>
+          </div>
+        </div>
+        <div className="space-y-2 p-4 bg-green-900/20 rounded-lg">
+          <h4 className="font-semibold text-green-100">Merge Partitions</h4>
+          <div className="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-2">
+            <input
+              type="number"
+              placeholder="Left PID"
+              value={mergeLeft}
+              onChange={e => setMergeLeft(e.target.value)}
+              className={inputClass}
+            />
+            <input
+              type="number"
+              placeholder="Right PID"
+              value={mergeRight}
+              onChange={e => setMergeRight(e.target.value)}
+              className={inputClass}
+            />
+            <Button onClick={handleMerge} disabled={!mergeLeft || !mergeRight || isLoading} size="sm">
+              Merge
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Card>
+  );
+};
+
+export default PartitionActions;

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -243,6 +243,32 @@ export const markHotKey = async (
   );
 };
 
+export const splitPartition = async (
+  pid: number,
+  splitKey?: string,
+): Promise<void> => {
+  const params = new URLSearchParams({ pid: String(pid) });
+  if (splitKey) params.append('split_key', splitKey);
+  await fetchJson<{ status: string }>(
+    `/cluster/actions/split_partition?${params.toString()}`,
+    { method: 'POST' },
+  );
+};
+
+export const mergePartitions = async (
+  pid1: number,
+  pid2: number,
+): Promise<void> => {
+  const params = new URLSearchParams({
+    pid1: String(pid1),
+    pid2: String(pid2),
+  });
+  await fetchJson<{ status: string }>(
+    `/cluster/actions/merge_partitions?${params.toString()}`,
+    { method: 'POST' },
+  );
+};
+
 export const rebalance = async (): Promise<void> => {
   await fetchJson<{ status: string }>('/cluster/actions/rebalance', {
     method: 'POST',

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -10,4 +10,6 @@ export {
   getMemtableEntries,
   getSstables,
   getSstableEntries,
+  splitPartition,
+  mergePartitions,
 } from './api';


### PR DESCRIPTION
## Summary
- add API helpers `splitPartition` and `mergePartitions`
- export new helpers
- create `PartitionActions` component with basic forms
- show `PartitionActions` in management page

## Testing
- `npm test --prefix app`
- `python -m unittest`

------
https://chatgpt.com/codex/tasks/task_e_68652fbef0308331a79ea5ef3d681ee7