### PR TITLE
Refactor request helper

### DIFF
--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -10,22 +10,7 @@ import {
   StorageEntry,
   SSTableInfo,
 } from '../types';
-
-const API_BASE = 'http://localhost:8000';
-
-const fetchJson = async <T>(path: string, options?: RequestInit): Promise<T> => {
-  const resp = await fetch(`${API_BASE}${path}`, options);
-  if (!resp.ok) {
-    throw new Error(`Request failed: ${resp.status}`);
-  }
-  if (
-    resp.status === 204 ||
-    (resp.headers && 'get' in resp.headers && resp.headers.get('content-length') === '0')
-  ) {
-    return {} as T;
-  }
-  return resp.json() as Promise<T>;
-};
+import { fetchJson } from './request';
 
 export const getNodes = async (): Promise<Node[]> => {
   const data = await fetchJson<{ nodes: any[] }>('/cluster/nodes');

--- a/app/services/databaseService.ts
+++ b/app/services/databaseService.ts
@@ -1,17 +1,5 @@
 import { UserRecord } from '../types';
-
-const API_BASE = 'http://localhost:8000';
-
-const fetchJson = async <T>(path: string, options?: RequestInit): Promise<T> => {
-  const resp = await fetch(`${API_BASE}${path}`, options);
-  if (!resp.ok) {
-    throw new Error(`Request failed: ${resp.status}`);
-  }
-  if (resp.headers.get('content-length') === '0' || resp.status === 204) {
-    return {} as T;
-  }
-  return resp.json() as Promise<T>;
-};
+import { fetchJson } from './request';
 
 export const getUserRecords = async (): Promise<UserRecord[]> => {
   const data = await fetchJson<{ records: { partition_key: string; clustering_key: string; value: string }[] }>('/data/records');

--- a/app/services/request.ts
+++ b/app/services/request.ts
@@ -1,0 +1,15 @@
+export const API_BASE = 'http://localhost:8000';
+
+export const fetchJson = async <T>(path: string, options?: RequestInit): Promise<T> => {
+  const resp = await fetch(`${API_BASE}${path}`, options);
+  if (!resp.ok) {
+    throw new Error(`Request failed: ${resp.status}`);
+  }
+  if (
+    resp.status === 204 ||
+    (resp.headers && 'get' in resp.headers && resp.headers.get('content-length') === '0')
+  ) {
+    return {} as T;
+  }
+  return resp.json() as Promise<T>;
+};


### PR DESCRIPTION
## Summary
- create a shared `fetchJson` helper
- reuse helper in api service and database service

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_686539578b68833185d153a763f095f8