### PR TITLE
Add component test for PartitionActions UI

### DIFF
--- a/app/tests/PartitionActions.test.tsx
+++ b/app/tests/PartitionActions.test.tsx
@@ -1,0 +1,33 @@
+import { vi } from 'vitest'
+
+vi.mock('../services/api', () => ({
+  splitPartition: vi.fn(),
+  mergePartitions: vi.fn(),
+}))
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PartitionActions from '../components/management/PartitionActions'
+import { splitPartition, mergePartitions } from '../services/api'
+
+describe('PartitionActions', () => {
+  it('calls splitPartition when Split is clicked', async () => {
+    render(<PartitionActions />)
+    fireEvent.change(screen.getByPlaceholderText('Partition ID'), { target: { value: '3' } })
+    fireEvent.change(screen.getByPlaceholderText('Split Key (optional)'), { target: { value: 'k' } })
+    fireEvent.click(screen.getByText('Split'))
+    await waitFor(() => {
+      expect(splitPartition).toHaveBeenCalledWith(3, 'k')
+    })
+  })
+
+  it('calls mergePartitions when Merge is clicked', async () => {
+    render(<PartitionActions />)
+    fireEvent.change(screen.getByPlaceholderText('Left PID'), { target: { value: '1' } })
+    fireEvent.change(screen.getByPlaceholderText('Right PID'), { target: { value: '2' } })
+    fireEvent.click(screen.getByText('Merge'))
+    await waitFor(() => {
+      expect(mergePartitions).toHaveBeenCalledWith(1, 2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add component tests for partition split/merge actions

## Testing
- `npm test --silent`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6865392d4b508331a4c95fbcd1978593