### PR TITLE
Add configurable API base URL

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -10,5 +10,6 @@ This contains everything you need to run your app locally.
 1. Install dependencies:
    `npm install`
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
+3. (Optional) Set `VITE_API_BASE` in [.env.local](.env.local) to the backend API base URL (defaults to `http://localhost:8000`)
+4. Run the app:
    `npm run dev`

--- a/app/services/request.ts
+++ b/app/services/request.ts
@@ -1,4 +1,6 @@
-export const API_BASE = 'http://localhost:8000';
+export const API_BASE =
+  (typeof import.meta !== 'undefined' && (import.meta as any).env?.VITE_API_BASE) ||
+  'http://localhost:8000';
 
 export const fetchJson = async <T>(path: string, options?: RequestInit): Promise<T> => {
   const resp = await fetch(`${API_BASE}${path}`, options);

--- a/app/vite-env.d.ts
+++ b/app/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -6,7 +6,8 @@ export default defineConfig(({ mode }) => {
     return {
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.VITE_API_BASE': JSON.stringify(env.VITE_API_BASE)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- expose `VITE_API_BASE` in the Vite config
- default `fetchJson` helper to `http://localhost:8000`
- document the optional variable in the frontend README
- add `vite-env.d.ts` for TypeScript env typings

## Testing
- `npm test`
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68653cc76e848331a7944b591d8f58da