### PR TITLE
Add tests for management components

### DIFF
--- a/app/tests/NodeDetail.test.tsx
+++ b/app/tests/NodeDetail.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+import NodeDetail from '../components/management/NodeDetail'
+import { NodeStatus, type Node } from '../types'
+
+vi.mock('../components/management/StorageInspector', () => ({
+  default: () => <div data-testid="inspector" />,
+}))
+
+const node: Node = {
+  id: 'node1',
+  address: 'localhost:9000',
+  status: NodeStatus.SUSPECT,
+  uptime: '1d',
+  cpuUsage: 1,
+  memoryUsage: 2,
+  diskUsage: 3,
+  dataLoad: 0,
+  replicationLogSize: 0,
+  hintsCount: 0,
+}
+
+describe('NodeDetail', () => {
+  it('renders details and triggers callbacks', () => {
+    const onRemove = vi.fn()
+    const onStop = vi.fn()
+    const onStart = vi.fn()
+    render(
+      <NodeDetail
+        node={node}
+        onRemove={onRemove}
+        onStop={onStop}
+        onStart={onStart}
+        isLoading={false}
+      />
+    )
+
+    expect(screen.getByText(`Node: ${node.id}`)).toBeInTheDocument()
+    expect(screen.getByText(node.address)).toBeInTheDocument()
+    expect(screen.getByText(node.status)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Start'))
+    expect(onStart).toHaveBeenCalledWith(node.id)
+
+    fireEvent.click(screen.getByText('Stop'))
+    expect(onStop).toHaveBeenCalledWith(node.id)
+
+    fireEvent.click(screen.getByText('Remove Node'))
+    expect(onRemove).toHaveBeenCalledWith(node.id)
+  })
+})

--- a/app/tests/NodeSelector.test.tsx
+++ b/app/tests/NodeSelector.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+import NodeSelector from '../components/management/NodeSelector'
+import { NodeStatus, type Node } from '../types'
+
+const nodes: Node[] = [
+  { id: 'n1', address: 'addr1', status: NodeStatus.LIVE, uptime: '1d', cpuUsage: 1, memoryUsage: 2, diskUsage: 3, dataLoad: 0, replicationLogSize: 0, hintsCount: 0 },
+  { id: 'n2', address: 'addr2', status: NodeStatus.DEAD, uptime: '2d', cpuUsage: 1, memoryUsage: 2, diskUsage: 3, dataLoad: 0, replicationLogSize: 0, hintsCount: 0 },
+]
+
+describe('NodeSelector', () => {
+  it('renders nodes and handles selection and add', () => {
+    const onSelect = vi.fn()
+    const onAdd = vi.fn()
+    render(
+      <NodeSelector
+        nodes={nodes}
+        selectedNodeId={null}
+        onSelectNode={onSelect}
+        onAddNode={onAdd}
+        isActionLoading={false}
+      />
+    )
+
+    expect(screen.getByText('Cluster Nodes')).toBeInTheDocument()
+    expect(screen.getByText('n1')).toBeInTheDocument()
+    expect(screen.getByText('n2')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('n2'))
+    expect(onSelect).toHaveBeenCalledWith('n2')
+
+    fireEvent.click(screen.getByText('Add New Node'))
+    expect(onAdd).toHaveBeenCalled()
+  })
+
+  it('shows loading state when adding', () => {
+    render(
+      <NodeSelector
+        nodes={nodes.slice(0, 1)}
+        selectedNodeId={'n1'}
+        onSelectNode={() => {}}
+        onAddNode={() => {}}
+        isActionLoading={true}
+      />
+    )
+
+    const btn = screen.getByText('Adding...')
+    expect(btn).toBeDisabled()
+  })
+})

--- a/app/tests/PartitionList.test.tsx
+++ b/app/tests/PartitionList.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import PartitionList from '../components/dashboard/PartitionList'
+import { type Partition } from '../types'
+
+const partitions: Partition[] = [
+  { id: 'p1', primaryNodeId: 'n1', replicaNodeIds: ['n2'], keyRange: ['a', 'z'], size: 1, itemCount: 100, operationCount: 0 },
+]
+
+describe('PartitionList', () => {
+  it('renders partition table', () => {
+    render(<PartitionList partitions={partitions} />)
+    expect(screen.getByText('Partitions')).toBeInTheDocument()
+    expect(screen.getByText('p1')).toBeInTheDocument()
+  })
+
+  it('shows empty message', () => {
+    render(<PartitionList partitions={[]} />)
+    expect(screen.getByText('No partitions found.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for NodeSelector component
- add tests for NodeDetail component
- add tests for PartitionList component

## Testing
- `npm --prefix app test`

------
https://chatgpt.com/codex/tasks/task_e_68653ee06f4c8331b48629710c24fa4d