### PR TITLE
Fix router setup path

### DIFF
--- a/setup_router.sh
+++ b/setup_router.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
-python -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. replica/router.proto
+python -m grpc_tools.protoc -I database/replication \
+    --python_out=. --grpc_python_out=. \
+    database/replication/replica/router.proto


### PR DESCRIPTION
## Summary
- adjust setup_router.sh to run protoc from repository root

## Testing
- `python -m unittest tests/test_router.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68653f0374fc83318250d4abe99ab37f