### PR TITLE
Add SSTable content test

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -550,7 +550,11 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
 
     def GetSSTableContent(self, request, context):
         """Return all key/value pairs for a specific SSTable."""
-        entries = self._node.get_sstable_content(request.id)
+        # ``SSTableContentRequest`` defines the field ``sstable_id`` to specify
+        # which table should be returned. Older versions used ``id`` so handle
+        # both for compatibility.
+        sst_id = getattr(request, "sstable_id", None) or getattr(request, "id", "")
+        entries = self._node.get_sstable_content(sst_id)
         return replication_pb2.StorageEntriesResponse(entries=entries)
 
 class HeartbeatService(replication_pb2_grpc.HeartbeatServiceServicer):

--- a/tests/test_sstable_content.py
+++ b/tests/test_sstable_content.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from database.replication.replica.grpc_server import NodeServer
+from database.replication.replica.client import GRPCReplicaClient
+
+
+class SSTableContentRPCTest(unittest.TestCase):
+    def test_get_sstable_content(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir, port=9110, node_id="A", peers=[])
+            node.server.start()
+            try:
+                node.db.put("k1", "v1")
+                node.db._flush_memtable_to_sstable()
+                seg = node.db.sstable_manager.sstable_segments[-1]
+                sstable_id = os.path.basename(seg[1])
+
+                client = GRPCReplicaClient("localhost", 9110)
+                entries = client.get_sstable_content(sstable_id, node_id="A")
+                client.close()
+
+                self.assertEqual(len(entries), 1)
+                self.assertEqual(entries[0][0], "k1")
+                self.assertEqual(entries[0][1], "v1")
+            finally:
+                node.server.stop(0).wait()
+                node.db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test exercising GRPCReplicaClient.get_sstable_content
- fix server to accept `sstable_id` field when returning SSTable content

## Testing
- `pytest -q tests/test_sstable_content.py`

------
https://chatgpt.com/codex/tasks/task_e_68653f0a4ac48331825b43baf7cd23cd