### PR TITLE
Add loading state test for NodeDetail

### DIFF
--- a/app/tests/NodeDetail.test.tsx
+++ b/app/tests/NodeDetail.test.tsx
@@ -49,4 +49,20 @@ describe('NodeDetail', () => {
     fireEvent.click(screen.getByText('Remove Node'))
     expect(onRemove).toHaveBeenCalledWith(node.id)
   })
+
+  it('disables actions when loading', () => {
+    render(
+      <NodeDetail
+        node={node}
+        onRemove={() => {}}
+        onStop={() => {}}
+        onStart={() => {}}
+        isLoading={true}
+      />
+    )
+
+    expect(screen.getByText('Start')).toBeDisabled()
+    expect(screen.getByText('Stop')).toBeDisabled()
+    expect(screen.getByText('Remove Node')).toBeDisabled()
+  })
 })


### PR DESCRIPTION
## Summary
- test NodeDetail buttons disable while loading

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68654912640883319a26ba83d2030397