### PR TITLE
Add example cluster scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,3 +496,14 @@ app/                 # Frontend web application
  setup_router.sh     # helper script to run the router
  tests/              # test cases
 ```
+
+## Example configurations
+
+Several small scripts under `examples/` start the cluster with different options. Each one also launches the API and React UI in the background. Run them with `python examples/<file>.py` and visit the printed URLs.
+
+- `hash_cluster.py` – three-node hash-partitioned cluster using LWW.
+- `range_cluster.py` – cluster with two explicit key ranges and sample composite keys.
+- `index_cluster.py` – enables `index_fields` and stores indexed records.
+- `router_cluster.py` – starts the gRPC router and writes via the router client.
+- `registry_cluster.py` – uses the metadata registry together with the router.
+

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -1,0 +1,50 @@
+import os
+import subprocess
+import time
+
+from api.main import app
+from database.replication import NodeCluster
+
+
+def start_services():
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = subprocess.Popen([
+        "npm",
+        "run",
+        "dev",
+    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
+    print("API running at http://localhost:8000")
+    print("Frontend running at http://localhost:5173")
+    return api_proc, frontend_proc
+
+
+def main():
+    app.router.on_startup.clear()
+    cluster = NodeCluster(
+        base_path="/tmp/hash_cluster",
+        num_nodes=3,
+        partition_strategy="hash",
+        consistency_mode="lww",
+    )
+    cluster.put(0, "k1", "v1")
+    cluster.put(0, "k2", "v2")
+    app.state.cluster = cluster
+    api_proc, front_proc = start_services()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        api_proc.terminate()
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+import time
+import json
+
+from api.main import app
+from database.replication import NodeCluster
+
+
+def start_services():
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = subprocess.Popen([
+        "npm",
+        "run",
+        "dev",
+    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
+    print("API running at http://localhost:8000")
+    print("Frontend running at http://localhost:5173")
+    return api_proc, frontend_proc
+
+
+def main():
+    app.router.on_startup.clear()
+    cluster = NodeCluster(base_path="/tmp/index_cluster", num_nodes=3, index_fields=["color"])
+    cluster.put(0, "p1", json.dumps({"color": "red"}))
+    cluster.put(0, "p2", json.dumps({"color": "blue"}))
+    app.state.cluster = cluster
+    api_proc, front_proc = start_services()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        api_proc.terminate()
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -1,0 +1,47 @@
+import os
+import subprocess
+import time
+
+from api.main import app
+from database.replication import NodeCluster
+from database.clustering.partitioning import compose_key
+
+
+def start_services():
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = subprocess.Popen([
+        "npm",
+        "run",
+        "dev",
+    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
+    print("API running at http://localhost:8000")
+    print("Frontend running at http://localhost:5173")
+    return api_proc, frontend_proc
+
+
+def main():
+    app.router.on_startup.clear()
+    ranges = [("a", "m"), ("m", "z")]
+    cluster = NodeCluster(base_path="/tmp/range_cluster", num_nodes=3, key_ranges=ranges)
+    cluster.put(0, compose_key("a", "1"), "v1")
+    cluster.put(0, compose_key("b", "2"), "v2")
+    app.state.cluster = cluster
+    api_proc, front_proc = start_services()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        api_proc.terminate()
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import time
+
+from api.main import app
+from database.replication import NodeCluster
+
+
+def start_services():
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = subprocess.Popen([
+        "npm",
+        "run",
+        "dev",
+    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
+    print("API running at http://localhost:8000")
+    print("Frontend running at http://localhost:5173")
+    return api_proc, frontend_proc
+
+
+def main():
+    app.router.on_startup.clear()
+    ranges = [("a", "m"), ("m", "z")]
+    cluster = NodeCluster(
+        base_path="/tmp/registry_cluster",
+        num_nodes=2,
+        key_ranges=ranges,
+        start_router=True,
+        use_registry=True,
+    )
+    cluster.router_client.put("reg1", "v1")
+    app.state.cluster = cluster
+    api_proc, front_proc = start_services()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        api_proc.terminate()
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -1,0 +1,45 @@
+import os
+import subprocess
+import time
+
+from api.main import app
+from database.replication import NodeCluster
+
+
+def start_services():
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = subprocess.Popen([
+        "npm",
+        "run",
+        "dev",
+    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
+    print("API running at http://localhost:8000")
+    print("Frontend running at http://localhost:5173")
+    return api_proc, frontend_proc
+
+
+def main():
+    app.router.on_startup.clear()
+    cluster = NodeCluster(base_path="/tmp/router_cluster", num_nodes=2, start_router=True)
+    cluster.router_client.put("r1", "v1")
+    cluster.router_client.put("r2", "v2")
+    app.state.cluster = cluster
+    api_proc, front_proc = start_services()
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        api_proc.terminate()
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Python examples demonstrating different cluster setups
- start uvicorn and React app from each example
- document example scripts in README

## Testing
- `python -m unittest discover -s tests -v` *(fails: test_write_with_hinted_substitute)*

------
https://chatgpt.com/codex/tasks/task_e_68654add559c8331b0a9e559e2f9383a