### PR TITLE
Fix hinted handoff test

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -1075,8 +1075,8 @@ class NodeServer:
         while not self._hinted_stop.is_set():
             updated = False
             for peer_id, hints in list(self.hints.items()):
-                if self.peer_status.get(peer_id) is None:
-                    continue
+                # Attempt handoff regardless of heartbeat status to reduce
+                # latency when a node comes back online.
                 client = self.clients_by_id.get(peer_id) or self.client_map.get(peer_id)
                 if not client:
                     continue


### PR DESCRIPTION
## Summary
- do not wait for heartbeat before sending hints

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68654e3193108331a03684f81a9dbec1