### PR TITLE
Add Dockerfile and Windows instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir -r requirements.txt
+CMD ["python", "examples/hash_cluster.py"]

--- a/README.md
+++ b/README.md
@@ -507,3 +507,18 @@ Several small scripts under `examples/` start the cluster with different options
 - `router_cluster.py` – starts the gRPC router and writes via the router client.
 - `registry_cluster.py` – uses the metadata registry together with the router.
 
+
+## Running the examples on Windows
+
+To avoid compatibility issues on Windows, run the project inside Docker. First install **Docker Desktop**, then build and run the image from the repository root:
+
+```bash
+docker build -t py_db .
+docker run -p 8000:8000 -p 5173:5173 py_db
+```
+
+This starts `hash_cluster.py`, which also launches the API and React UI in the background. You can run a different example by overriding the command:
+
+```bash
+docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
+```

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -860,3 +860,18 @@ curl "http://localhost:8000/data/query_index?field=color&value=red"
 - `lsm_db.py`, `mem_table.py`, `wal.py`, `sstable.py` – implementação da LSM Tree.
 - `replication.py` e `replica/` – lógica de replicação gRPC e serviços.
 - `tests/` – casos de teste.
+
+## Executando os exemplos no Windows
+
+Para evitar problemas de compatibilidade no Windows, utilize o Docker. Primeiro instale o **Docker Desktop**, depois construa e execute a imagem na raiz do repositório:
+
+```bash
+docker build -t py_db .
+docker run -p 8000:8000 -p 5173:5173 py_db
+```
+
+Esse comando inicia o `hash_cluster.py`, que também lança a API e a interface React em segundo plano. Para rodar outro exemplo, basta sobrescrever o comando:
+
+```bash
+docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
+```


### PR DESCRIPTION
## Summary
- add Dockerfile for running examples
- document how to run the examples on Windows using Docker

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_686553cafb2483318d0340f6a4da129d