### PR TITLE
Fix Dockerfile and example path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM python:3.10-slim
+
+# Install node for the React frontend
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY . /app
+
+# Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
+
+# Install frontend dependencies
+RUN cd app && npm install --legacy-peer-deps
+
 CMD ["python", "examples/hash_cluster.py"]

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -1,6 +1,10 @@
 import os
+import sys
 import subprocess
 import time
+
+# Ensure project root is on the import path just like the tests do
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from api.main import app
 from database.replication import NodeCluster


### PR DESCRIPTION
## Summary
- ensure project root is in `sys.path` for examples
- install node and frontend deps in Dockerfile so React UI can run

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_node_start_stop.py::NodeStartStopTest::test_stop_and_start_node -q`

------
https://chatgpt.com/codex/tasks/task_e_686562ebf9d88331968f1f4ff08e24ac