### PR TITLE
Enable optional ngrok tunnels for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,13 @@ Several small scripts under `examples/` start the cluster with different options
 - `router_cluster.py` – starts the gRPC router and writes via the router client.
 - `registry_cluster.py` – uses the metadata registry together with the router.
 
+When executing inside environments without direct access to localhost (e.g. Google Colab) pass `--tunnel` to expose both services via ngrok:
+
+```bash
+python examples/hash_cluster.py --tunnel
+```
+The external URLs will be printed once the tunnels are ready. Set `NGROK_AUTHTOKEN` to use your own ngrok account.
+
 
 ## Running the examples on Windows
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -875,3 +875,10 @@ Esse comando inicia o `hash_cluster.py`, que também lança a API e a interface 
 ```bash
 docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
 ```
+
+Em ambientes remotos sem acesso ao `localhost` (como o Google Colab) utilize a opção `--tunnel` para expor a API e a interface através do ngrok:
+
+```bash
+python examples/hash_cluster.py --tunnel
+```
+Os endereços públicos serão exibidos assim que o túnel estiver ativo. Defina `NGROK_AUTHTOKEN` para usar sua conta do ngrok.

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -9,8 +9,13 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -22,12 +27,18 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = ngrok.connect(5173, bind_tls=True).public_url
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173"
+    print(f"API running at {api_url}")
+    print(f"Frontend running at {ui_url}")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     cluster = NodeCluster(
         base_path="/tmp/hash_cluster",
@@ -38,7 +49,7 @@ def main():
     cluster.put(0, "k1", "v1")
     cluster.put(0, "k2", "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -48,7 +59,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -6,8 +6,13 @@ import json
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -19,18 +24,24 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = ngrok.connect(5173, bind_tls=True).public_url
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173"
+    print(f"API running at {api_url}")
+    print(f"Frontend running at {ui_url}")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     cluster = NodeCluster(base_path="/tmp/index_cluster", num_nodes=3, index_fields=["color"])
     cluster.put(0, "p1", json.dumps({"color": "red"}))
     cluster.put(0, "p2", json.dumps({"color": "blue"}))
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -40,7 +51,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -6,8 +6,13 @@ from api.main import app
 from database.replication import NodeCluster
 from database.clustering.partitioning import compose_key
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -19,19 +24,25 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = ngrok.connect(5173, bind_tls=True).public_url
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173"
+    print(f"API running at {api_url}")
+    print(f"Frontend running at {ui_url}")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
     cluster = NodeCluster(base_path="/tmp/range_cluster", num_nodes=3, key_ranges=ranges)
     cluster.put(0, compose_key("a", "1"), "v1")
     cluster.put(0, compose_key("b", "2"), "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -41,7 +52,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -5,8 +5,13 @@ import time
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -18,18 +23,24 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = ngrok.connect(5173, bind_tls=True).public_url
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173"
+    print(f"API running at {api_url}")
+    print(f"Frontend running at {ui_url}")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     cluster = NodeCluster(base_path="/tmp/router_cluster", num_nodes=2, start_router=True)
     cluster.router_client.put("r1", "v1")
     cluster.router_client.put("r2", "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -39,7 +50,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ protobuf<7.0.0,>=6.30.0
 fastapi
 uvicorn
 httpx<0.25
+pyngrok


### PR DESCRIPTION
## Summary
- add `pyngrok` dependency
- allow passing `--tunnel` to example scripts so API and frontend can be exposed through ngrok
- document usage of the new option in README and README_pt_BR

## Testing
- `python -m py_compile examples/*.py`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656e6776508331ace0b5037f5ac03e