### PR TITLE
Enable optional tunnels reliably

### DIFF
--- a/README.md
+++ b/README.md
@@ -507,6 +507,20 @@ Several small scripts under `examples/` start the cluster with different options
 - `router_cluster.py` – starts the gRPC router and writes via the router client.
 - `registry_cluster.py` – uses the metadata registry together with the router.
 
+When executing inside environments without direct access to localhost (e.g. Google Colab) pass `--tunnel` to expose both services via ngrok:
+
+```bash
+python examples/hash_cluster.py --tunnel
+```
+The external URLs will be printed once the tunnels are ready. Set `NGROK_AUTHTOKEN` to use your own ngrok account.
+
+Before running an example for the first time, install the UI dependencies:
+
+```bash
+cd app && npm install
+```
+The scripts wait for port 5173 to become available; if the frontend fails to start the tunnel will be skipped.
+
 
 ## Running the examples on Windows
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -875,3 +875,17 @@ Esse comando inicia o `hash_cluster.py`, que também lança a API e a interface 
 ```bash
 docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
 ```
+
+Em ambientes remotos sem acesso ao `localhost` (como o Google Colab) utilize a opção `--tunnel` para expor a API e a interface através do ngrok:
+
+```bash
+python examples/hash_cluster.py --tunnel
+```
+Os endereços públicos serão exibidos assim que o túnel estiver ativo. Defina `NGROK_AUTHTOKEN` para usar sua conta do ngrok.
+
+Antes de executar um exemplo pela primeira vez, instale as dependências da interface:
+
+```bash
+cd app && npm install
+```
+Os scripts aguardam a porta 5173 ficar disponível; caso a interface não inicie o túnel correspondente será ignorado.

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -2,6 +2,7 @@ import os
 import sys
 import subprocess
 import time
+import socket
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -9,8 +10,25 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def wait_port(port: int, host: str = "127.0.0.1", timeout: float = 30.0) -> bool:
+    """Wait until a TCP port is open."""
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), 1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -22,12 +40,27 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    wait_port(8000)
+    ui_ready = wait_port(5173)
+
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = (
+            ngrok.connect(5173, bind_tls=True).public_url if ui_ready else None
+        )
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173" if ui_ready else None
+
+    print(f"API running at {api_url}")
+    if ui_url:
+        print(f"Frontend running at {ui_url}")
+    else:
+        print("Frontend failed to start on port 5173")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     cluster = NodeCluster(
         base_path="/tmp/hash_cluster",
@@ -38,7 +71,7 @@ def main():
     cluster.put(0, "k1", "v1")
     cluster.put(0, "k2", "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -48,7 +81,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -2,12 +2,29 @@ import os
 import subprocess
 import time
 import json
+import socket
 
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def wait_port(port: int, host: str = "127.0.0.1", timeout: float = 30.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), 1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -19,18 +36,33 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    wait_port(8000)
+    ui_ready = wait_port(5173)
+
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = (
+            ngrok.connect(5173, bind_tls=True).public_url if ui_ready else None
+        )
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173" if ui_ready else None
+
+    print(f"API running at {api_url}")
+    if ui_url:
+        print(f"Frontend running at {ui_url}")
+    else:
+        print("Frontend failed to start on port 5173")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     cluster = NodeCluster(base_path="/tmp/index_cluster", num_nodes=3, index_fields=["color"])
     cluster.put(0, "p1", json.dumps({"color": "red"}))
     cluster.put(0, "p2", json.dumps({"color": "blue"}))
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -40,7 +72,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -1,13 +1,30 @@
 import os
 import subprocess
 import time
+import socket
 
 from api.main import app
 from database.replication import NodeCluster
 from database.clustering.partitioning import compose_key
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def wait_port(port: int, host: str = "127.0.0.1", timeout: float = 30.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), 1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -19,19 +36,34 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    wait_port(8000)
+    ui_ready = wait_port(5173)
+
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = (
+            ngrok.connect(5173, bind_tls=True).public_url if ui_ready else None
+        )
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173" if ui_ready else None
+
+    print(f"API running at {api_url}")
+    if ui_url:
+        print(f"Frontend running at {ui_url}")
+    else:
+        print("Frontend failed to start on port 5173")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
     cluster = NodeCluster(base_path="/tmp/range_cluster", num_nodes=3, key_ranges=ranges)
     cluster.put(0, compose_key("a", "1"), "v1")
     cluster.put(0, compose_key("b", "2"), "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -41,7 +73,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -1,12 +1,29 @@
 import os
 import subprocess
 import time
+import socket
 
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def wait_port(port: int, host: str = "127.0.0.1", timeout: float = 30.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), 1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -18,12 +35,27 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    wait_port(8000)
+    ui_ready = wait_port(5173)
+
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = (
+            ngrok.connect(5173, bind_tls=True).public_url if ui_ready else None
+        )
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173" if ui_ready else None
+
+    print(f"API running at {api_url}")
+    if ui_url:
+        print(f"Frontend running at {ui_url}")
+    else:
+        print("Frontend failed to start on port 5173")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
     cluster = NodeCluster(
@@ -35,7 +67,7 @@ def main():
     )
     cluster.router_client.put("reg1", "v1")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -45,7 +77,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -1,12 +1,29 @@
 import os
 import subprocess
 import time
+import socket
 
 from api.main import app
 from database.replication import NodeCluster
 
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:
+    ngrok = None
 
-def start_services():
+
+def wait_port(port: int, host: str = "127.0.0.1", timeout: float = 30.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            with socket.create_connection((host, port), 1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def start_services(tunnel: bool = False):
     api_proc = subprocess.Popen([
         "uvicorn",
         "api.main:app",
@@ -18,18 +35,33 @@ def start_services():
         "run",
         "dev",
     ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    print("API running at http://localhost:8000")
-    print("Frontend running at http://localhost:5173")
+    wait_port(8000)
+    ui_ready = wait_port(5173)
+
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = (
+            ngrok.connect(5173, bind_tls=True).public_url if ui_ready else None
+        )
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173" if ui_ready else None
+
+    print(f"API running at {api_url}")
+    if ui_url:
+        print(f"Frontend running at {ui_url}")
+    else:
+        print("Frontend failed to start on port 5173")
     return api_proc, frontend_proc
 
 
-def main():
+def main(tunnel: bool = False):
     app.router.on_startup.clear()
     cluster = NodeCluster(base_path="/tmp/router_cluster", num_nodes=2, start_router=True)
     cluster.router_client.put("r1", "v1")
     cluster.router_client.put("r2", "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services()
+    api_proc, front_proc = start_services(tunnel)
     try:
         while True:
             time.sleep(1)
@@ -39,7 +71,18 @@ def main():
         api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
+        if tunnel and ngrok:
+            ngrok.kill()
 
 
 if __name__ == "__main__":
-    main()
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tunnel",
+        action="store_true",
+        help="Expose API and UI using ngrok",
+    )
+    args = parser.parse_args()
+    main(tunnel=args.tunnel)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ protobuf<7.0.0,>=6.30.0
 fastapi
 uvicorn
 httpx<0.25
+pyngrok


### PR DESCRIPTION
## Summary
- handle asynchronous UI startup by waiting for port 5173 before opening an ngrok tunnel
- document the need to run `npm install` before launching the examples
- add wait logic to all example scripts

## Testing
- `python -m py_compile examples/*.py`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656e6776508331ace0b5037f5ac03e