### PR TITLE
Run API and frontend together

### DIFF
--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import subprocess
 import time
 
 # Ensure project root is on the import path just like the tests do
@@ -8,34 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from api.main import app
 from database.replication import NodeCluster
-
-try:
-    from pyngrok import ngrok  # type: ignore
-except Exception:
-    ngrok = None
-
-
-def start_services(tunnel: bool = False):
-    api_proc = subprocess.Popen([
-        "uvicorn",
-        "api.main:app",
-        "--port",
-        "8000",
-    ])
-    frontend_proc = subprocess.Popen([
-        "npm",
-        "run",
-        "dev",
-    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    if tunnel and ngrok:
-        api_url = ngrok.connect(8000, bind_tls=True).public_url
-        ui_url = ngrok.connect(5173, bind_tls=True).public_url
-    else:
-        api_url = "http://localhost:8000"
-        ui_url = "http://localhost:5173"
-    print(f"API running at {api_url}")
-    print(f"Frontend running at {ui_url}")
-    return api_proc, frontend_proc
+from .service_runner import start_services, ngrok
 
 
 def main(tunnel: bool = False):

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -1,38 +1,10 @@
 import os
-import subprocess
-import time
 import json
+import time
 
 from api.main import app
 from database.replication import NodeCluster
-
-try:
-    from pyngrok import ngrok  # type: ignore
-except Exception:
-    ngrok = None
-
-
-def start_services(tunnel: bool = False):
-    api_proc = subprocess.Popen([
-        "uvicorn",
-        "api.main:app",
-        "--port",
-        "8000",
-    ])
-    frontend_proc = subprocess.Popen([
-        "npm",
-        "run",
-        "dev",
-    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    if tunnel and ngrok:
-        api_url = ngrok.connect(8000, bind_tls=True).public_url
-        ui_url = ngrok.connect(5173, bind_tls=True).public_url
-    else:
-        api_url = "http://localhost:8000"
-        ui_url = "http://localhost:5173"
-    print(f"API running at {api_url}")
-    print(f"Frontend running at {ui_url}")
-    return api_proc, frontend_proc
+from .service_runner import start_services, ngrok
 
 
 def main(tunnel: bool = False):

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -1,38 +1,10 @@
 import os
-import subprocess
 import time
 
 from api.main import app
 from database.replication import NodeCluster
 from database.clustering.partitioning import compose_key
-
-try:
-    from pyngrok import ngrok  # type: ignore
-except Exception:
-    ngrok = None
-
-
-def start_services(tunnel: bool = False):
-    api_proc = subprocess.Popen([
-        "uvicorn",
-        "api.main:app",
-        "--port",
-        "8000",
-    ])
-    frontend_proc = subprocess.Popen([
-        "npm",
-        "run",
-        "dev",
-    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    if tunnel and ngrok:
-        api_url = ngrok.connect(8000, bind_tls=True).public_url
-        ui_url = ngrok.connect(5173, bind_tls=True).public_url
-    else:
-        api_url = "http://localhost:8000"
-        ui_url = "http://localhost:5173"
-    print(f"API running at {api_url}")
-    print(f"Frontend running at {ui_url}")
-    return api_proc, frontend_proc
+from .service_runner import start_services, ngrok
 
 
 def main(tunnel: bool = False):

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -1,37 +1,9 @@
 import os
-import subprocess
 import time
 
 from api.main import app
 from database.replication import NodeCluster
-
-try:
-    from pyngrok import ngrok  # type: ignore
-except Exception:
-    ngrok = None
-
-
-def start_services(tunnel: bool = False):
-    api_proc = subprocess.Popen([
-        "uvicorn",
-        "api.main:app",
-        "--port",
-        "8000",
-    ])
-    frontend_proc = subprocess.Popen([
-        "npm",
-        "run",
-        "dev",
-    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    if tunnel and ngrok:
-        api_url = ngrok.connect(8000, bind_tls=True).public_url
-        ui_url = ngrok.connect(5173, bind_tls=True).public_url
-    else:
-        api_url = "http://localhost:8000"
-        ui_url = "http://localhost:5173"
-    print(f"API running at {api_url}")
-    print(f"Frontend running at {ui_url}")
-    return api_proc, frontend_proc
+from .service_runner import start_services, ngrok
 
 
 def main(tunnel: bool = False):

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -1,37 +1,9 @@
 import os
-import subprocess
 import time
 
 from api.main import app
 from database.replication import NodeCluster
-
-try:
-    from pyngrok import ngrok  # type: ignore
-except Exception:
-    ngrok = None
-
-
-def start_services(tunnel: bool = False):
-    api_proc = subprocess.Popen([
-        "uvicorn",
-        "api.main:app",
-        "--port",
-        "8000",
-    ])
-    frontend_proc = subprocess.Popen([
-        "npm",
-        "run",
-        "dev",
-    ], cwd=os.path.join(os.path.dirname(__file__), "..", "app"))
-    if tunnel and ngrok:
-        api_url = ngrok.connect(8000, bind_tls=True).public_url
-        ui_url = ngrok.connect(5173, bind_tls=True).public_url
-    else:
-        api_url = "http://localhost:8000"
-        ui_url = "http://localhost:5173"
-    print(f"API running at {api_url}")
-    print(f"Frontend running at {ui_url}")
-    return api_proc, frontend_proc
+from .service_runner import start_services, ngrok
 
 
 def main(tunnel: bool = False):

--- a/examples/service_runner.py
+++ b/examples/service_runner.py
@@ -1,0 +1,32 @@
+import os
+import subprocess
+
+try:
+    from pyngrok import ngrok  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    ngrok = None
+
+
+def start_services(tunnel: bool = False):
+    """Start API and frontend servers, optionally tunneling via ngrok."""
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = subprocess.Popen(
+        ["npm", "run", "dev"],
+        cwd=os.path.join(os.path.dirname(__file__), "..", "app"),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+    if tunnel and ngrok:
+        api_url = ngrok.connect(8000, bind_tls=True).public_url
+        ui_url = ngrok.connect(5173, bind_tls=True).public_url
+    else:
+        api_url = "http://localhost:8000"
+        ui_url = "http://localhost:5173"
+    print(f"API running at {api_url}")
+    print(f"Frontend running at {ui_url}")
+    return api_proc, frontend_proc


### PR DESCRIPTION
## Summary
- create `service_runner.start_services` to launch the API and Vite UI
- reuse the helper in example scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686577814fdc8331ad7b31b63eee12fe