### PR TITLE
Update example scripts for frontend-only tunneling

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ app/                 # Frontend web application
 
 ## Example configurations
 
-Several small scripts under `examples/` start the cluster with different options. Each one also launches the API and React UI in the background. Run them with `python examples/<file>.py` and visit the printed URLs.
+Several small scripts under `examples/` start the cluster with different options. Each one launches the React UI in the background while the API runs in the foreground. Run them with `python examples/<file>.py` and visit the printed URLs.
 
 - `hash_cluster.py` – three-node hash-partitioned cluster using LWW.
 - `range_cluster.py` – cluster with two explicit key ranges and sample composite keys.
@@ -507,12 +507,12 @@ Several small scripts under `examples/` start the cluster with different options
 - `router_cluster.py` – starts the gRPC router and writes via the router client.
 - `registry_cluster.py` – uses the metadata registry together with the router.
 
-When executing inside environments without direct access to localhost (e.g. Google Colab) pass `--tunnel` to expose both services via ngrok:
+When executing inside environments without direct access to localhost (e.g. Google Colab) pass `--tunnel` to expose the UI via ngrok:
 
 ```bash
 python examples/hash_cluster.py --tunnel
 ```
-The external URLs will be printed once the tunnels are ready. Set `NGROK_AUTHTOKEN` to use your own ngrok account.
+The UI URL will be printed once the tunnel is ready. Set `NGROK_AUTHTOKEN` to use your own ngrok account.
 
 
 ## Running the examples on Windows

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -870,15 +870,15 @@ docker build -t py_db .
 docker run -p 8000:8000 -p 5173:5173 py_db
 ```
 
-Esse comando inicia o `hash_cluster.py`, que também lança a API e a interface React em segundo plano. Para rodar outro exemplo, basta sobrescrever o comando:
+Esse comando inicia o `hash_cluster.py`, que lança a interface React em segundo plano enquanto a API roda em primeiro plano. Para rodar outro exemplo, basta sobrescrever o comando:
 
 ```bash
 docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
 ```
 
-Em ambientes remotos sem acesso ao `localhost` (como o Google Colab) utilize a opção `--tunnel` para expor a API e a interface através do ngrok:
+Em ambientes remotos sem acesso ao `localhost` (como o Google Colab) utilize a opção `--tunnel` para expor apenas a interface através do ngrok:
 
 ```bash
 python examples/hash_cluster.py --tunnel
 ```
-Os endereços públicos serão exibidos assim que o túnel estiver ativo. Defina `NGROK_AUTHTOKEN` para usar sua conta do ngrok.
+O endereço público da interface será exibido assim que o túnel estiver ativo. Defina `NGROK_AUTHTOKEN` para usar sua conta do ngrok.

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from api.main import app
 from database.replication import NodeCluster
-from examples.service_runner import start_services, ngrok
+from examples.service_runner import start_frontend, ngrok
 
 
 def main(tunnel: bool = False):
@@ -21,14 +21,12 @@ def main(tunnel: bool = False):
     cluster.put(0, "k1", "v1")
     cluster.put(0, "k2", "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services(tunnel)
+    front_proc = start_frontend(tunnel)
+    print("API running at http://localhost:8000")
     try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
     finally:
-        api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
         if tunnel and ngrok:

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -4,7 +4,7 @@ import time
 
 from api.main import app
 from database.replication import NodeCluster
-from .service_runner import start_services, ngrok
+from .service_runner import start_frontend, ngrok
 
 
 def main(tunnel: bool = False):
@@ -13,14 +13,12 @@ def main(tunnel: bool = False):
     cluster.put(0, "p1", json.dumps({"color": "red"}))
     cluster.put(0, "p2", json.dumps({"color": "blue"}))
     app.state.cluster = cluster
-    api_proc, front_proc = start_services(tunnel)
+    front_proc = start_frontend(tunnel)
+    print("API running at http://localhost:8000")
     try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
     finally:
-        api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
         if tunnel and ngrok:

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -4,7 +4,7 @@ import time
 from api.main import app
 from database.replication import NodeCluster
 from database.clustering.partitioning import compose_key
-from .service_runner import start_services, ngrok
+from .service_runner import start_frontend, ngrok
 
 
 def main(tunnel: bool = False):
@@ -14,14 +14,12 @@ def main(tunnel: bool = False):
     cluster.put(0, compose_key("a", "1"), "v1")
     cluster.put(0, compose_key("b", "2"), "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services(tunnel)
+    front_proc = start_frontend(tunnel)
+    print("API running at http://localhost:8000")
     try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
     finally:
-        api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
         if tunnel and ngrok:

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -3,7 +3,7 @@ import time
 
 from api.main import app
 from database.replication import NodeCluster
-from .service_runner import start_services, ngrok
+from .service_runner import start_frontend, ngrok
 
 
 def main(tunnel: bool = False):
@@ -18,14 +18,12 @@ def main(tunnel: bool = False):
     )
     cluster.router_client.put("reg1", "v1")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services(tunnel)
+    front_proc = start_frontend(tunnel)
+    print("API running at http://localhost:8000")
     try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
     finally:
-        api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
         if tunnel and ngrok:

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -3,7 +3,7 @@ import time
 
 from api.main import app
 from database.replication import NodeCluster
-from .service_runner import start_services, ngrok
+from .service_runner import start_frontend, ngrok
 
 
 def main(tunnel: bool = False):
@@ -12,14 +12,12 @@ def main(tunnel: bool = False):
     cluster.router_client.put("r1", "v1")
     cluster.router_client.put("r2", "v2")
     app.state.cluster = cluster
-    api_proc, front_proc = start_services(tunnel)
+    front_proc = start_frontend(tunnel)
+    print("API running at http://localhost:8000")
     try:
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
     finally:
-        api_proc.terminate()
         front_proc.terminate()
         cluster.shutdown()
         if tunnel and ngrok:

--- a/examples/service_runner.py
+++ b/examples/service_runner.py
@@ -7,29 +7,31 @@ except Exception:  # pragma: no cover - optional dependency
     ngrok = None
 
 
-def start_services(tunnel: bool = False):
-    """Start API and frontend servers, optionally tunneling via ngrok."""
-    api_proc = subprocess.Popen([
-        "uvicorn",
-        "api.main:app",
-        "--port",
-        "8000",
-    ],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT
-    )
-    frontend_proc = subprocess.Popen(
+def start_frontend(tunnel: bool = False):
+    """Start the React UI in the background and optionally tunnel it via ngrok."""
+    proc = subprocess.Popen(
         ["npm", "run", "dev"],
         cwd=os.path.join(os.path.dirname(__file__), "..", "app"),
         stdout=subprocess.DEVNULL,
         stderr=subprocess.STDOUT,
     )
     if tunnel and ngrok:
-        api_url = ngrok.connect(8000, bind_tls=True).public_url
         ui_url = ngrok.connect(5173, bind_tls=True).public_url
     else:
-        api_url = "http://localhost:8000"
         ui_url = "http://localhost:5173"
-    print(f"API running at {api_url}")
     print(f"Frontend running at {ui_url}")
+    return proc
+
+
+def start_services(tunnel: bool = False):
+    """Start API and frontend servers, tunneling only the UI if requested."""
+    api_proc = subprocess.Popen([
+        "uvicorn",
+        "api.main:app",
+        "--port",
+        "8000",
+    ])
+    frontend_proc = start_frontend(tunnel)
+    api_url = "http://localhost:8000"
+    print(f"API running at {api_url}")
     return api_proc, frontend_proc


### PR DESCRIPTION
## Summary
- expose only the frontend when using `--tunnel`
- run the API in the foreground
- update docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865859c49508331a1ded3fa27236117