### PR TITLE
Add durability test

### DIFF
--- a/tests/test_durability.py
+++ b/tests/test_durability.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from database.lsm.lsm_db import SimpleLSMDB
+
+
+class DurabilityTest(unittest.TestCase):
+    def test_recover_after_crash(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db1 = SimpleLSMDB(db_path=tmpdir, max_memtable_size=10)
+            db1.put("k1", "v1")
+            # Simulate crash by not calling close()
+            db2 = SimpleLSMDB(db_path=tmpdir, max_memtable_size=10)
+            self.assertEqual(db2.get("k1"), "v1")
+            db2.close()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add test_durability to ensure data recovery from WAL after crash
- refine durability test formatting to match other tests

## Testing
- `python -m unittest tests/test_durability.py -v`
- `pytest -q tests/test_lsm_db.py tests/test_durability.py`

------
https://chatgpt.com/codex/tasks/task_e_6865ad9ead7483319173284d5e29dc4b