### PR TITLE
Add transaction lock and concurrency test

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -66,9 +66,10 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
         self._node.clock.update(request.timestamp)
 
         if request.tx_id:
-            self._node.active_transactions.setdefault(request.tx_id, []).append(
-                ("put", request)
-            )
+            with self._node._tx_lock:
+                self._node.active_transactions.setdefault(request.tx_id, []).append(
+                    ("put", request)
+                )
             return replication_pb2.Empty()
 
         origem = seq = None
@@ -243,9 +244,10 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
         self._node.clock.update(request.timestamp)
 
         if request.tx_id:
-            self._node.active_transactions.setdefault(request.tx_id, []).append(
-                ("delete", request)
-            )
+            with self._node._tx_lock:
+                self._node.active_transactions.setdefault(request.tx_id, []).append(
+                    ("delete", request)
+                )
             return replication_pb2.Empty()
 
         origem = seq = None
@@ -413,11 +415,13 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
 
     def BeginTransaction(self, request, context):
         tx_id = uuid.uuid4().hex
-        self._node.active_transactions[tx_id] = []
+        with self._node._tx_lock:
+            self._node.active_transactions[tx_id] = []
         return replication_pb2.TransactionId(id=tx_id)
 
     def CommitTransaction(self, request, context):
-        ops = self._node.active_transactions.pop(request.tx_id, [])
+        with self._node._tx_lock:
+            ops = self._node.active_transactions.pop(request.tx_id, [])
         for op, req in ops:
             if op == "put":
                 new_req = replication_pb2.KeyValue(
@@ -445,7 +449,8 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
         return replication_pb2.Empty()
 
     def AbortTransaction(self, request, context):
-        self._node.active_transactions.pop(request.tx_id, None)
+        with self._node._tx_lock:
+            self._node.active_transactions.pop(request.tx_id, None)
         return replication_pb2.Empty()
 
     def ScanRange(self, request, context):
@@ -706,6 +711,7 @@ class NodeServer:
         self.last_seen: dict[str, int] = {}
         self.replication_log: dict[str, tuple] = {}
         self.active_transactions: dict[str, list[tuple]] = {}
+        self._tx_lock = threading.Lock()
         self._cleanup_stop = threading.Event()
         self._cleanup_thread = None
         self._replay_stop = threading.Event()

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -2,6 +2,7 @@ import os
 import sys
 import tempfile
 import unittest
+import threading
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -47,6 +48,53 @@ class TransactionTest(unittest.TestCase):
                 replication_pb2.TransactionControl(tx_id=tx2), None
             )
             self.assertIsNone(node.db.get("k2"))
+
+            node.db.close()
+
+    def test_concurrent_transaction_ops(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir)
+            service = ReplicaService(node)
+
+            tx_id = service.BeginTransaction(replication_pb2.Empty(), None).id
+
+            def do_put():
+                service.Put(
+                    replication_pb2.KeyValue(
+                        key="k",
+                        value="v",
+                        timestamp=1,
+                        tx_id=tx_id,
+                    ),
+                    None,
+                )
+
+            def do_del():
+                service.Delete(
+                    replication_pb2.KeyRequest(
+                        key="d",
+                        timestamp=1,
+                        tx_id=tx_id,
+                    ),
+                    None,
+                )
+
+            threads = [threading.Thread(target=do_put) for _ in range(5)] + [
+                threading.Thread(target=do_del) for _ in range(5)
+            ]
+
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join()
+
+            with node._tx_lock:
+                self.assertEqual(len(node.active_transactions[tx_id]), 10)
+
+            service.CommitTransaction(replication_pb2.TransactionControl(tx_id=tx_id), None)
+
+            self.assertEqual(node.db.get("k"), "v")
+            self.assertIsNone(node.db.get("d"))
 
             node.db.close()
 


### PR DESCRIPTION
## Summary
- guard accesses to `active_transactions` with a lock
- add `_tx_lock` attribute in `NodeServer`
- add regression test for concurrent transaction operations

## Testing
- `pytest -k transactions -q`

------
https://chatgpt.com/codex/tasks/task_e_6865d977e2e883319aa75b98c889baca