### PR TITLE
Add transaction usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,30 @@ Run only the routing and driver tests:
 python -m unittest tests/test_routing.py tests/test_smart_driver.py -v
 ```
 
+### Transactions
+
+Start a transaction using `BeginTransaction` and include the returned `tx_id`
+in every `Put` or `Delete` call. Writes are buffered until you either
+`CommitTransaction` to apply them or `AbortTransaction` to discard the queued
+operations.
+
+```python
+from replication import NodeCluster
+from replica.client import GRPCReplicaClient
+
+cluster = NodeCluster('/tmp/tx_demo', num_nodes=1)
+client = cluster.nodes[0].client
+
+tx = client.begin_transaction()
+client.put('key1', 'v1', tx_id=tx)
+client.delete('old', tx_id=tx)
+client.commit_transaction(tx)
+
+tx2 = client.begin_transaction()
+client.put('temp', '123', tx_id=tx2)
+client.abort_transaction(tx2)
+```
+
 ## Dedicated Routing Tier
 
 A standalone gRPC router can relay all client requests to the correct node. Start it by passing `start_router=True` when creating the cluster and connect using `GRPCRouterClient`.

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -798,6 +798,27 @@ Execute apenas os testes de roteamento e do driver:
 python -m unittest tests/test_routing.py tests/test_smart_driver.py -v
 ```
 
+### Transações
+
+Inicie uma transação usando `BeginTransaction` e inclua o `tx_id` retornado em
+cada chamada de `Put` ou `Delete`. As operações ficam em memória até que você
+execute `CommitTransaction` para aplicá-las ou `AbortTransaction` para
+descartá-las.
+
+```python
+cluster = NodeCluster('/tmp/tx_demo', num_nodes=1)
+cliente = cluster.nodes[0].client
+
+tx = cliente.begin_transaction()
+cliente.put('key1', 'v1', tx_id=tx)
+cliente.delete('old', tx_id=tx)
+cliente.commit_transaction(tx)
+
+tx2 = cliente.begin_transaction()
+cliente.put('temp', '123', tx_id=tx2)
+cliente.abort_transaction(tx2)
+```
+
 ## Dedicated Routing Tier
 
 A standalone gRPC router can relay all client requests to the correct node.


### PR DESCRIPTION
## Summary
- document transaction workflow via gRPC client
- add the same section in Portuguese README

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_6865d9817bac8331be3aa2b3de8d5205