### PR TITLE
Document transaction RPCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,9 +447,10 @@ python -m unittest tests/test_routing.py tests/test_smart_driver.py -v
 ### Transactions
 
 Start a transaction using `BeginTransaction` and include the returned `tx_id`
-in every `Put` or `Delete` call. Writes are buffered until you either
-`CommitTransaction` to apply them or `AbortTransaction` to discard the queued
-operations.
+in every `Put` or `Delete` call. Writes remain buffered on the server until you
+issue the `CommitTransaction` RPC to apply them or `AbortTransaction` to
+discard the queued operations. Both RPCs are defined in
+`database/replication/replica/replication.proto`.
 
 ```python
 from replication import NodeCluster

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -802,8 +802,9 @@ python -m unittest tests/test_routing.py tests/test_smart_driver.py -v
 
 Inicie uma transação usando `BeginTransaction` e inclua o `tx_id` retornado em
 cada chamada de `Put` ou `Delete`. As operações ficam em memória até que você
-execute `CommitTransaction` para aplicá-las ou `AbortTransaction` para
-descartá-las.
+envie a chamada gRPC `CommitTransaction` para aplicá-las ou `AbortTransaction`
+para descartá-las. Esses métodos estão definidos em
+`database/replication/replica/replication.proto`.
 
 ```python
 cluster = NodeCluster('/tmp/tx_demo', num_nodes=1)

--- a/database/replication/replica/replication.proto
+++ b/database/replication/replica/replication.proto
@@ -231,7 +231,9 @@ service Replica {
   rpc Delete(KeyRequest) returns (Empty);
   rpc Get(KeyRequest) returns (ValueResponse);
   rpc BeginTransaction(Empty) returns (TransactionId);
+  // Apply all buffered operations of a transaction
   rpc CommitTransaction(TransactionControl) returns (Empty);
+  // Discard any pending operations of a transaction
   rpc AbortTransaction(TransactionControl) returns (Empty);
   rpc ScanRange(RangeRequest) returns (RangeResponse);
   rpc FetchUpdates(FetchRequest) returns (FetchResponse);


### PR DESCRIPTION
## Summary
- clarify transaction operations in docs
- document CommitTransaction and AbortTransaction RPCs in proto

## Testing
- `pytest tests/test_transactions.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6865de328a1083318ca30a1be4e4c729