### PR TITLE
Implement basic read committed isolation

### DIFF
--- a/database/replication/replica/client.py
+++ b/database/replication/replica/client.py
@@ -93,9 +93,11 @@ class GRPCReplicaClient:
         self._ensure_channel()
         self.stub.Delete(request)
 
-    def get(self, key):
+    def get(self, key, *, tx_id: str = ""):
         self._ensure_channel()
-        request = replication_pb2.KeyRequest(key=key, timestamp=0, node_id="")
+        request = replication_pb2.KeyRequest(
+            key=key, timestamp=0, node_id="", tx_id=tx_id
+        )
         response = self.stub.Get(request)
         results = []
         for item in response.values:
@@ -347,9 +349,11 @@ class GRPCRouterClient:
         self._ensure_channel()
         self.stub.Delete(request)
 
-    def get(self, key):
+    def get(self, key, *, tx_id: str = ""):
         self._ensure_channel()
-        request = replication_pb2.KeyRequest(key=key, timestamp=0, node_id="")
+        request = replication_pb2.KeyRequest(
+            key=key, timestamp=0, node_id="", tx_id=tx_id
+        )
         response = self.stub.Get(request)
         results = []
         for item in response.values:


### PR DESCRIPTION
## Summary
- extend Get RPC with logic to ignore uncommitted changes from other transactions
- allow gRPC clients to send tx_id on get operations
- add a test validating dirty read prevention

## Testing
- `pytest tests/test_transactions.py::TransactionTest::test_dirty_read_prevention -q`
- `pytest -q` *(ran all tests, see log)*

------
https://chatgpt.com/codex/tasks/task_e_6865ebc882d88331b234e50cc644e2b0