### PR TITLE
Add test to show write skew prevention via GetForUpdate

### DIFF
--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 import threading
+import time
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -19,7 +20,9 @@ class TransactionTest(unittest.TestCase):
             # start transaction and buffer operations
             tx_id = service.BeginTransaction(replication_pb2.Empty(), None).id
             service.Put(
-                replication_pb2.KeyValue(key="k1", value="v1", timestamp=1, tx_id=tx_id),
+                replication_pb2.KeyValue(
+                    key="k1", value="v1", timestamp=1, tx_id=tx_id
+                ),
                 None,
             )
             node.db.put("d", "val", timestamp=1)
@@ -91,7 +94,9 @@ class TransactionTest(unittest.TestCase):
             with node._tx_lock:
                 self.assertEqual(len(node.active_transactions[tx_id]), 10)
 
-            service.CommitTransaction(replication_pb2.TransactionControl(tx_id=tx_id), None)
+            service.CommitTransaction(
+                replication_pb2.TransactionControl(tx_id=tx_id), None
+            )
 
             self.assertEqual(node.db.get("k"), "v")
             self.assertIsNone(node.db.get("d"))
@@ -113,25 +118,19 @@ class TransactionTest(unittest.TestCase):
             )
 
             # another transaction should still see committed value
-            resp = service.Get(
-                replication_pb2.KeyRequest(key="k", tx_id=""), None
-            )
+            resp = service.Get(replication_pb2.KeyRequest(key="k", tx_id=""), None)
             self.assertEqual(len(resp.values), 1)
             self.assertEqual(resp.values[0].value, "v0")
 
             tx2 = service.BeginTransaction(replication_pb2.Empty(), None).id
-            resp2 = service.Get(
-                replication_pb2.KeyRequest(key="k", tx_id=tx2), None
-            )
+            resp2 = service.Get(replication_pb2.KeyRequest(key="k", tx_id=tx2), None)
             self.assertEqual(len(resp2.values), 1)
             self.assertEqual(resp2.values[0].value, "v0")
 
             service.CommitTransaction(
                 replication_pb2.TransactionControl(tx_id=tx1), None
             )
-            resp3 = service.Get(
-                replication_pb2.KeyRequest(key="k", tx_id=""), None
-            )
+            resp3 = service.Get(replication_pb2.KeyRequest(key="k", tx_id=""), None)
             self.assertEqual(len(resp3.values), 0)
 
             node.db.close()
@@ -146,9 +145,7 @@ class TransactionTest(unittest.TestCase):
             tx1 = service.BeginTransaction(replication_pb2.Empty(), None).id
             tx2 = service.BeginTransaction(replication_pb2.Empty(), None).id
 
-            service.GetForUpdate(
-                replication_pb2.KeyRequest(key="k", tx_id=tx1), None
-            )
+            service.GetForUpdate(replication_pb2.KeyRequest(key="k", tx_id=tx1), None)
 
             with self.assertRaises(RuntimeError):
                 service.GetForUpdate(
@@ -159,12 +156,84 @@ class TransactionTest(unittest.TestCase):
                 replication_pb2.TransactionControl(tx_id=tx1), None
             )
 
-            service.GetForUpdate(
-                replication_pb2.KeyRequest(key="k", tx_id=tx2), None
-            )
+            service.GetForUpdate(replication_pb2.KeyRequest(key="k", tx_id=tx2), None)
             service.AbortTransaction(
                 replication_pb2.TransactionControl(tx_id=tx2), None
             )
+
+            node.db.close()
+
+    def test_prevent_write_skew_using_get_for_update(self):
+        """Ensure application invariant holds using row locks."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            node = NodeServer(db_path=tmpdir)
+            service = ReplicaService(node)
+
+            node.db.put("doc1", "on", timestamp=1)
+            node.db.put("doc2", "on", timestamp=1)
+
+            start = threading.Barrier(2)
+
+            def leave(doc_key):
+                start.wait()
+                tx_id = service.BeginTransaction(replication_pb2.Empty(), None).id
+
+                while True:
+                    try:
+                        service.GetForUpdate(
+                            replication_pb2.KeyRequest(key="doc1", tx_id=tx_id),
+                            None,
+                        )
+                        service.GetForUpdate(
+                            replication_pb2.KeyRequest(key="doc2", tx_id=tx_id),
+                            None,
+                        )
+                        break
+                    except RuntimeError:
+                        service.AbortTransaction(
+                            replication_pb2.TransactionControl(tx_id=tx_id), None
+                        )
+                        time.sleep(0.01)
+                        tx_id = service.BeginTransaction(
+                            replication_pb2.Empty(), None
+                        ).id
+
+                resp1 = service.Get(
+                    replication_pb2.KeyRequest(key="doc1", tx_id=tx_id), None
+                )
+                resp2 = service.Get(
+                    replication_pb2.KeyRequest(key="doc2", tx_id=tx_id), None
+                )
+                count = (1 if resp1.values else 0) + (1 if resp2.values else 0)
+                if count > 1:
+                    service.Delete(
+                        replication_pb2.KeyRequest(
+                            key=doc_key, timestamp=2, tx_id=tx_id
+                        ),
+                        None,
+                    )
+                    service.CommitTransaction(
+                        replication_pb2.TransactionControl(tx_id=tx_id), None
+                    )
+                else:
+                    service.AbortTransaction(
+                        replication_pb2.TransactionControl(tx_id=tx_id), None
+                    )
+
+            t1 = threading.Thread(target=leave, args=("doc1",))
+            t2 = threading.Thread(target=leave, args=("doc2",))
+            t1.start()
+            t2.start()
+            t1.join()
+            t2.join()
+
+            remaining = 0
+            if node.db.get("doc1") is not None:
+                remaining += 1
+            if node.db.get("doc2") is not None:
+                remaining += 1
+
+            self.assertEqual(remaining, 1)
 
             node.db.close()
 


### PR DESCRIPTION
## Summary
- extend transaction tests with a scenario to prevent write skew
- ensure threads acquire locks via `GetForUpdate` before modifying doctor rows
- verify that only one doctor leaves thanks to locking

## Testing
- `pytest -k transactions -vv`

------
https://chatgpt.com/codex/tasks/task_e_686669c17c808331b8f92a430e02577a