### PR TITLE
Implement basic MVCC skeleton

### DIFF
--- a/database/lsm/sstable.py
+++ b/database/lsm/sstable.py
@@ -27,22 +27,33 @@ def _merge_version_lists(current, new_list):
     if not current:
         return list(new_list)
     result = list(current)
-    for val, vc in new_list:
+    for item in new_list:
+        val, vc = item[0], item[1]
+        created = item[2] if len(item) > 2 else None
+        deleted = item[3] if len(item) > 3 else None
         add_new = True
         updated = []
-        for c_val, c_vc in result:
+        for cur in result:
+            c_val, c_vc = cur[0], cur[1]
+            c_created = cur[2] if len(cur) > 2 else None
+            c_deleted = cur[3] if len(cur) > 3 else None
             cmp = vc.compare(c_vc)
             if cmp == ">":
                 continue
             if cmp == "<":
                 add_new = False
-                updated.append((c_val, c_vc))
+                updated.append((c_val, c_vc, c_created, c_deleted))
             else:
-                if vc.clock == c_vc.clock and val == c_val:
+                if (
+                    vc.clock == c_vc.clock
+                    and val == c_val
+                    and created == c_created
+                    and deleted == c_deleted
+                ):
                     add_new = False
-                updated.append((c_val, c_vc))
+                updated.append((c_val, c_vc, c_created, c_deleted))
         if add_new:
-            updated.append((val, vc))
+            updated.append((val, vc, created, deleted))
         result = updated
     return result
 

--- a/database/lsm/wal.py
+++ b/database/lsm/wal.py
@@ -17,7 +17,9 @@ class WriteAheadLog(object):
             with open(self.wal_file_path, 'w') as f:
                 pass # Apenas cria o arquivo
     
-    def append(self, entry_type, key, value, vector_clock=None, *, clustering_key=None):
+    def append(
+        self, entry_type, key, value, vector_clock=None, *, clustering_key=None
+    ):
         """Adiciona registro ao WAL com o vetor associado."""
         if vector_clock is None:
             vector_clock = VectorClock()
@@ -49,7 +51,10 @@ class WriteAheadLog(object):
                             0,
                             data.get("type"),
                             data.get("key"),
-                            (data.get("value"), VectorClock(data.get("vector", {}))),
+                            (
+                                data.get("value"),
+                                VectorClock(data.get("vector", {})),
+                            ),
                         )
                     )
                 except json.JSONDecodeError:

--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -123,7 +123,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             elif mode in ("vector", "crdt"):
                 versions = self._node.db.get_record(request.key)
                 dominated = False
-                for _, vc in versions:
+                for _, vc, *_ in versions:
                     cmp = new_vc.compare(vc)
                     if cmp == "<":
                         dominated = True
@@ -146,7 +146,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             else:  # lww
                 versions = self._node.db.get_record(request.key)
                 latest_ts = -1
-                for _, vc in versions:
+                for _, vc, *_ in versions:
                     ts_val = vc.clock.get("ts", 0)
                     if ts_val > latest_ts:
                         latest_ts = ts_val
@@ -290,7 +290,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             if mode in ("vector", "crdt"):
                 versions = self._node.db.get_record(request.key)
                 dominated = False
-                for _, vc in versions:
+                for _, vc, *_ in versions:
                     cmp = new_vc.compare(vc)
                     if cmp == "<":
                         dominated = True
@@ -308,7 +308,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             else:  # lww
                 versions = self._node.db.get_record(request.key)
                 latest_ts = -1
-                for _, vc in versions:
+                for _, vc, *_ in versions:
                     ts_val = vc.clock.get("ts", 0)
                     if ts_val > latest_ts:
                         latest_ts = ts_val
@@ -436,7 +436,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
             return replication_pb2.ValueResponse(values=[])
 
         values = []
-        for val, vc in records:
+        for val, vc, *_ in records:
             ts = vc.clock.get("ts", 0) if vc is not None else 0
             values.append(
                 replication_pb2.VersionedValue(
@@ -619,7 +619,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
                 local_tree = build_merkle_tree(items)
                 diff_keys = diff_trees(local_tree, remote_trees.get(seg))
                 for key in diff_keys:
-                    for val, vc in self._node.db.get_record(key):
+                    for val, vc, *_ in self._node.db.get_record(key):
                         ts_val = vc.clock.get("ts", 0) if vc is not None else 0
                         ops.append(
                             replication_pb2.Operation(
@@ -1099,7 +1099,7 @@ class NodeServer:
         """Return current MemTable items."""
         entries = []
         for key, versions in self.db.memtable.get_sorted_items():
-            for val, vc in versions:
+            for val, vc, *_ in versions:
                 if val == "__TOMBSTONE__":
                     continue
                 entries.append(

--- a/database/utils/merkle.py
+++ b/database/utils/merkle.py
@@ -33,7 +33,8 @@ def compute_segment_hashes(db) -> Dict[str, str]:
     if hasattr(db, "memtable"):
         items = []
         for k, versions in db.memtable.get_sorted_items():
-            for val, _vc in versions:
+            for item in versions:
+                val = item[0]
                 if val != "__TOMBSTONE__":
                     items.append((k, val))
         hashes["memtable"] = merkle_root(items)


### PR DESCRIPTION
## Summary
- add sequential txid generator on `NodeCluster`
- track node tx ids in `Driver`
- store created/deleted tx ids in MemTable and SimpleLSMDB
- extend version merge helpers for new tuple format
- adapt replication code for extended tuples
- fix tuple iteration when computing segment hashes and in gRPC server

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68667cc04d108331814e1bc4cde59bd6