### PR TITLE
Improve partition selection in UI

### DIFF
--- a/app/components/management/PartitionActions.tsx
+++ b/app/components/management/PartitionActions.tsx
@@ -1,7 +1,12 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button';
-import { splitPartition, mergePartitions } from '../../services/api';
+import {
+  splitPartition,
+  mergePartitions,
+  getPartitions,
+} from '../../services/api';
+import { Partition } from '../../types';
 
 const PartitionActions: React.FC = () => {
   const [splitPid, setSplitPid] = useState('');
@@ -9,6 +14,19 @@ const PartitionActions: React.FC = () => {
   const [mergeLeft, setMergeLeft] = useState('');
   const [mergeRight, setMergeRight] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+  const [partitions, setPartitions] = useState<Partition[]>([]);
+
+  useEffect(() => {
+    const fetchPartitions = async () => {
+      try {
+        const parts = await getPartitions();
+        setPartitions(parts);
+      } catch (err) {
+        console.error('Failed to fetch partitions:', err);
+      }
+    };
+    fetchPartitions();
+  }, []);
 
   const handleSplit = async () => {
     if (!splitPid) return;
@@ -44,13 +62,19 @@ const PartitionActions: React.FC = () => {
         <div className="space-y-2 p-4 bg-green-900/20 rounded-lg">
           <h4 className="font-semibold text-green-100">Split Partition</h4>
           <div className="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-2">
-            <input
-              type="number"
-              placeholder="Partition ID"
+            <select
+              aria-label="Split PID"
               value={splitPid}
               onChange={e => setSplitPid(e.target.value)}
               className={inputClass}
-            />
+            >
+              <option value="">Select Partition</option>
+              {partitions.map(p => (
+                <option key={p.id} value={p.id}>
+                  {p.id}
+                </option>
+              ))}
+            </select>
             <input
               type="text"
               placeholder="Split Key (optional)"
@@ -66,20 +90,32 @@ const PartitionActions: React.FC = () => {
         <div className="space-y-2 p-4 bg-green-900/20 rounded-lg">
           <h4 className="font-semibold text-green-100">Merge Partitions</h4>
           <div className="flex flex-col sm:flex-row items-center space-y-2 sm:space-y-0 sm:space-x-2">
-            <input
-              type="number"
-              placeholder="Left PID"
+            <select
+              aria-label="Left PID"
               value={mergeLeft}
               onChange={e => setMergeLeft(e.target.value)}
               className={inputClass}
-            />
-            <input
-              type="number"
-              placeholder="Right PID"
+            >
+              <option value="">Select Partition</option>
+              {partitions.map(p => (
+                <option key={p.id} value={p.id}>
+                  {p.id}
+                </option>
+              ))}
+            </select>
+            <select
+              aria-label="Right PID"
               value={mergeRight}
               onChange={e => setMergeRight(e.target.value)}
               className={inputClass}
-            />
+            >
+              <option value="">Select Partition</option>
+              {partitions.map(p => (
+                <option key={p.id} value={p.id}>
+                  {p.id}
+                </option>
+              ))}
+            </select>
             <Button onClick={handleMerge} disabled={!mergeLeft || !mergeRight || isLoading} size="sm">
               Merge
             </Button>

--- a/app/tests/PartitionActions.test.tsx
+++ b/app/tests/PartitionActions.test.tsx
@@ -3,6 +3,9 @@ import { vi } from 'vitest'
 vi.mock('../services/api', () => ({
   splitPartition: vi.fn(),
   mergePartitions: vi.fn(),
+  getPartitions: vi
+    .fn()
+    .mockResolvedValue([{ id: '1' } as any, { id: '2' } as any, { id: '3' } as any]),
 }))
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
@@ -13,7 +16,8 @@ import { splitPartition, mergePartitions } from '../services/api'
 describe('PartitionActions', () => {
   it('calls splitPartition when Split is clicked', async () => {
     render(<PartitionActions />)
-    fireEvent.change(screen.getByPlaceholderText('Partition ID'), { target: { value: '3' } })
+    await screen.findAllByText('3')
+    fireEvent.change(screen.getByLabelText('Split PID'), { target: { value: '3' } })
     fireEvent.change(screen.getByPlaceholderText('Split Key (optional)'), { target: { value: 'k' } })
     fireEvent.click(screen.getByText('Split'))
     await waitFor(() => {
@@ -23,8 +27,9 @@ describe('PartitionActions', () => {
 
   it('calls mergePartitions when Merge is clicked', async () => {
     render(<PartitionActions />)
-    fireEvent.change(screen.getByPlaceholderText('Left PID'), { target: { value: '1' } })
-    fireEvent.change(screen.getByPlaceholderText('Right PID'), { target: { value: '2' } })
+    await screen.findAllByText('3')
+    fireEvent.change(screen.getByLabelText('Left PID'), { target: { value: '1' } })
+    fireEvent.change(screen.getByLabelText('Right PID'), { target: { value: '2' } })
     fireEvent.click(screen.getByText('Merge'))
     await waitFor(() => {
       expect(mergePartitions).toHaveBeenCalledWith(1, 2)


### PR DESCRIPTION
## Summary
- show dropdown lists of partitions for splitting and merging
- fetch partition list from API inside `PartitionActions`
- update tests for new UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c93730088331b58f80f978869a5f