### PR TITLE
Allow creating records without clustering key

### DIFF
--- a/app/components/DataBrowser.tsx
+++ b/app/components/DataBrowser.tsx
@@ -35,7 +35,7 @@ const DataBrowser: React.FC = () => {
     const filteredData = records.filter(item => {
       return (
         item.partitionKey.toLowerCase().includes(lowercasedFilter) ||
-        item.clusteringKey.toLowerCase().includes(lowercasedFilter) ||
+        item.clusteringKey?.toLowerCase().includes(lowercasedFilter) ||
         item.value.toLowerCase().includes(lowercasedFilter)
       );
     });
@@ -64,9 +64,10 @@ const DataBrowser: React.FC = () => {
     await fetchData(); // Refresh data
   };
 
-  const handleDeleteRecord = async (partitionKey: string, clusteringKey: string) => {
-    if (window.confirm(`Are you sure you want to delete record with key ${partitionKey} | ${clusteringKey}?`)) {
-        await databaseService.deleteUserRecord(partitionKey, clusteringKey);
+  const handleDeleteRecord = async (partitionKey: string, clusteringKey?: string) => {
+    const label = clusteringKey ? ` | ${clusteringKey}` : '';
+    if (window.confirm(`Are you sure you want to delete record with key ${partitionKey}${label}?`)) {
+        await databaseService.deleteUserRecord(partitionKey, clusteringKey ?? '');
         await fetchData();
     }
   };

--- a/app/components/databrowser/DataEditorModal.tsx
+++ b/app/components/databrowser/DataEditorModal.tsx
@@ -13,40 +13,27 @@ const DataEditorModal: React.FC<DataEditorModalProps> = ({ isOpen, onClose, onSa
   const [partitionKey, setPartitionKey] = useState('');
   const [clusteringKey, setClusteringKey] = useState('');
   const [value, setValue] = useState('');
-  const [jsonError, setJsonError] = useState('');
 
   useEffect(() => {
     if (record) {
       setPartitionKey(record.partitionKey);
-      setClusteringKey(record.clusteringKey);
+      setClusteringKey(record.clusteringKey || '');
       setValue(record.value);
     } else {
       setPartitionKey('');
       setClusteringKey('');
-      setValue('{}');
+      setValue('');
     }
-    setJsonError('');
   }, [record, isOpen]);
 
   if (!isOpen) return null;
 
   const handleValueChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value;
-    setValue(newValue);
-    try {
-      JSON.parse(newValue);
-      setJsonError('');
-    } catch (error) {
-      setJsonError('Invalid JSON format.');
-    }
+    setValue(e.target.value);
   };
 
   const handleSave = () => {
-    if (jsonError) {
-      alert('Cannot save with invalid JSON.');
-      return;
-    }
-    onSave({ partitionKey, clusteringKey, value });
+    onSave({ partitionKey, clusteringKey: clusteringKey || undefined, value });
   };
 
   return (
@@ -81,22 +68,19 @@ const DataEditorModal: React.FC<DataEditorModalProps> = ({ isOpen, onClose, onSa
             </div>
           </div>
           <div>
-            <label htmlFor="value" className="block text-sm font-medium text-green-300 mb-1">Value (JSON)</label>
+            <label htmlFor="value" className="block text-sm font-medium text-green-300 mb-1">Value</label>
             <textarea
               id="value"
               rows={10}
               value={value}
               onChange={handleValueChange}
-              className={`w-full bg-[#10180f] border rounded-md px-3 py-2 text-white font-mono text-sm placeholder-green-500 focus:outline-none focus:ring-2 ${
-                jsonError ? 'border-red-500 focus:ring-red-500' : 'border-green-700/50 focus:ring-green-500'
-              }`}
+              className="w-full bg-[#10180f] border border-green-700/50 rounded-md px-3 py-2 text-white font-mono text-sm placeholder-green-500 focus:outline-none focus:ring-2 focus:ring-green-500"
             />
-            {jsonError && <p className="text-red-400 text-xs mt-1">{jsonError}</p>}
           </div>
         </div>
         <div className="p-4 bg-[#141f17] border-t border-green-800/60 flex justify-end space-x-3">
           <Button variant="secondary" onClick={onClose}>Cancel</Button>
-          <Button variant="primary" onClick={handleSave} disabled={!partitionKey || !clusteringKey || !!jsonError}>
+          <Button variant="primary" onClick={handleSave} disabled={!partitionKey}>
             {record ? 'Save Changes' : 'Create Record'}
           </Button>
         </div>

--- a/app/components/databrowser/DataTable.tsx
+++ b/app/components/databrowser/DataTable.tsx
@@ -6,7 +6,7 @@ import Button from '../common/Button';
 interface DataTableProps {
   records: UserRecord[];
   onEdit: (record: UserRecord) => void;
-  onDelete: (partitionKey: string, clusteringKey: string) => void;
+  onDelete: (partitionKey: string, clusteringKey?: string) => void;
 }
 
 const DataTable: React.FC<DataTableProps> = ({ records, onEdit, onDelete }) => {
@@ -17,7 +17,7 @@ const DataTable: React.FC<DataTableProps> = ({ records, onEdit, onDelete }) => {
           <tr>
             <th scope="col" className="px-6 py-3">Partition Key</th>
             <th scope="col" className="px-6 py-3">Clustering Key</th>
-            <th scope="col" className="px-6 py-3">Value (JSON)</th>
+            <th scope="col" className="px-6 py-3">Value</th>
             <th scope="col" className="px-6 py-3 text-right">Actions</th>
           </tr>
         </thead>

--- a/app/tests/DataBrowser.test.tsx
+++ b/app/tests/DataBrowser.test.tsx
@@ -44,7 +44,7 @@ describe('DataBrowser', () => {
 
     fireEvent.change(screen.getByLabelText('Partition Key'), { target: { value: 'p3' } })
     fireEvent.change(screen.getByLabelText('Clustering Key'), { target: { value: 'c3' } })
-    fireEvent.change(screen.getByLabelText('Value (JSON)'), { target: { value: '{"b":3}' } })
+    fireEvent.change(screen.getByLabelText('Value'), { target: { value: '{"b":3}' } })
 
     fireEvent.click(screen.getByText('Create Record'))
     await waitFor(() => {

--- a/app/types.ts
+++ b/app/types.ts
@@ -36,8 +36,8 @@ export interface MetricPoint {
 
 export interface UserRecord {
   partitionKey: string;
-  clusteringKey: string;
-  value: string; // JSON string
+  clusteringKey?: string;
+  value: string; // free form text
 }
 
 export interface ClusterConfig {


### PR DESCRIPTION
## Summary
- support optional clusteringKey for records
- relax JSON requirement in DataEditorModal
- display plain value in the UI
- update service logic for records without clusteringKey
- adjust tests and components accordingly

## Testing
- `python -m unittest discover -s tests -v` *(fails: test_concurrent_transaction_ops, test_get_for_update_prevents_lost_update, test_concurrent_writes_merge)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867c8c25a0c8331b32c60ce0dc3fb50