### PR TITLE
Add cluster transactions API endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -191,6 +191,20 @@ def cluster_config() -> dict:
     }
 
 
+@app.get("/cluster/transactions")
+def cluster_transactions() -> dict:
+    """Return active transactions for each node in the cluster."""
+    cluster = app.state.cluster
+    results = []
+    for n in cluster.nodes:
+        try:
+            tx_ids = n.client.list_transactions()
+        except Exception:
+            tx_ids = []
+        results.append({"node": n.node_id, "tx_ids": tx_ids})
+    return {"transactions": results}
+
+
 @app.post("/cluster/actions/add_node")
 def add_node() -> dict:
     """Add a new node to the cluster and return its id."""

--- a/tests/api/test_transactions_api.py
+++ b/tests/api/test_transactions_api.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+
+
+def test_cluster_transactions_endpoint():
+    with TestClient(app) as client:
+        cluster = app.state.cluster
+        tx_id, _ = cluster.nodes[0].client.begin_transaction()
+        try:
+            resp = client.get("/cluster/transactions")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "transactions" in data
+            entries = {t["node"]: t["tx_ids"] for t in data["transactions"]}
+            assert tx_id in entries.get(cluster.nodes[0].node_id, [])
+        finally:
+            cluster.nodes[0].client.abort_transaction(tx_id)


### PR DESCRIPTION
## Summary
- add `/cluster/transactions` endpoint that returns active transactions per node
- test the new endpoint using `TestClient`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -k transactions_api -q`

------
https://chatgpt.com/codex/tasks/task_e_6867dc4f93748331a2bf34c4a936f959