### PR TITLE
Add transactions API client and test

### DIFF
--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -6,6 +6,7 @@ import {
   ClusterConfig,
   HotspotInfo,
   ReplicationStatus,
+  TransactionInfo,
   WALEntry,
   StorageEntry,
   SSTableInfo,
@@ -114,6 +115,16 @@ export const getReplicationStatus = async (): Promise<ReplicationStatus[]> => {
     })
   );
   return statuses;
+};
+
+export const getTransactions = async (): Promise<TransactionInfo[]> => {
+  const data = await fetchJson<{ transactions: { node: string; tx_ids: any[] }[] }>(
+    '/cluster/transactions',
+  );
+  return (data.transactions || []).map(t => ({
+    nodeId: t.node,
+    txIds: t.tx_ids || [],
+  }));
 };
 
 export const addNode = async (): Promise<string> => {

--- a/app/tests/transactions.test.ts
+++ b/app/tests/transactions.test.ts
@@ -1,0 +1,11 @@
+import { getTransactions } from '../services/api'
+import { vi } from 'vitest'
+
+describe('getTransactions', () => {
+  it('parses transactions from API', async () => {
+    const sample = { transactions: [ { node: 'n1', tx_ids: ['a', 'b'] } ] }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => sample }))
+    const res = await getTransactions()
+    expect(res).toEqual([{ nodeId: 'n1', txIds: ['a', 'b'] }])
+  })
+})

--- a/app/types.ts
+++ b/app/types.ts
@@ -99,3 +99,8 @@ export interface SSTableInfo {
     itemCount: number;
     keyRange: [string, string];
 }
+
+export interface TransactionInfo {
+    nodeId: string;
+    txIds: string[];
+}


### PR DESCRIPTION
## Summary
- add `TransactionInfo` interface
- implement `getTransactions` API call
- test transaction parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867dfb872088331aad13694eb6f7cf1