### PR TITLE
Enhance example data generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,8 @@ app/                 # Frontend web application
 
 Several small scripts under `examples/` start the cluster with different options. Each one launches the React UI in the background while the API runs in the foreground. Run them with `python examples/<file>.py` and visit the printed URLs.
 
+The scripts now populate the cluster using simple data generator functions so you can observe how each configuration behaves with a larger workload.
+
 - `hash_cluster.py` – three-node hash-partitioned cluster using LWW.
 - `range_cluster.py` – cluster with two explicit key ranges and sample composite keys.
 - `index_cluster.py` – enables `index_fields` and stores indexed records.

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -905,6 +905,9 @@ curl "http://localhost:8000/data/query_index?field=color&value=red"
 - `lsm_db.py`, `mem_table.py`, `wal.py`, `sstable.py` – implementação da LSM Tree.
 - `replication.py` e `replica/` – lógica de replicação gRPC e serviços.
 - `tests/` – casos de teste.
+- `examples/` – scripts de demonstração que geram dados automaticamente.
+
+Os exemplos inserem diversos registros aleatórios para demonstrar como cada configuração influencia a distribuição dos dados no cluster.
 
 ## Executando os exemplos no Windows
 

--- a/examples/data_generators.py
+++ b/examples/data_generators.py
@@ -1,0 +1,27 @@
+import json
+import random
+from database.clustering.partitioning import compose_key
+
+
+COLORS = ["red", "blue", "green", "yellow", "purple"]
+
+
+def generate_index_items(num: int = 10):
+    """Yield keys and JSON values with a random color field."""
+    for i in range(1, num + 1):
+        key = f"p{i}"
+        value = json.dumps({"color": random.choice(COLORS)})
+        yield key, value
+
+
+def generate_hash_items(num: int = 10):
+    """Yield simple key/value pairs."""
+    for i in range(1, num + 1):
+        yield f"k{i}", f"v{i}"
+
+
+def generate_range_items(num: int = 10):
+    """Yield composed keys suitable for range partitioning."""
+    for i in range(1, num + 1):
+        letter = chr(ord('a') + (i - 1) % 26)
+        yield compose_key(letter, str(i)), f"v{i}"

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import time
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -8,6 +7,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from api.main import app
 from database.replication import NodeCluster
 from examples.service_runner import start_frontend
+from examples.data_generators import generate_hash_items
 
 
 def main() -> None:
@@ -18,8 +18,8 @@ def main() -> None:
         partition_strategy="hash",
         consistency_mode="lww",
     )
-    cluster.put(0, "k1", "v1")
-    cluster.put(0, "k2", "v2")
+    for key, value in generate_hash_items(20):
+        cluster.put(0, key, value)
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -1,17 +1,20 @@
-import os
 import json
-import time
 
 from api.main import app
 from database.replication import NodeCluster
 from .service_runner import start_frontend
+from .data_generators import generate_index_items
 
 
 def main() -> None:
     app.router.on_startup.clear()
-    cluster = NodeCluster(base_path="/tmp/index_cluster", num_nodes=3, index_fields=["color"])
-    cluster.put(0, "p1", json.dumps({"color": "red"}))
-    cluster.put(0, "p2", json.dumps({"color": "blue"}))
+    cluster = NodeCluster(
+        base_path="/tmp/index_cluster",
+        num_nodes=3,
+        index_fields=["color"],
+    )
+    for key, value in generate_index_items(20):
+        cluster.put(0, key, value)
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -1,18 +1,19 @@
-import os
-import time
-
 from api.main import app
 from database.replication import NodeCluster
-from database.clustering.partitioning import compose_key
 from .service_runner import start_frontend
+from .data_generators import generate_range_items
 
 
 def main() -> None:
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
-    cluster = NodeCluster(base_path="/tmp/range_cluster", num_nodes=3, key_ranges=ranges)
-    cluster.put(0, compose_key("a", "1"), "v1")
-    cluster.put(0, compose_key("b", "2"), "v2")
+    cluster = NodeCluster(
+        base_path="/tmp/range_cluster",
+        num_nodes=3,
+        key_ranges=ranges,
+    )
+    for key, value in generate_range_items(20):
+        cluster.put(0, key, value)
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -1,9 +1,7 @@
-import os
-import time
-
 from api.main import app
 from database.replication import NodeCluster
 from .service_runner import start_frontend
+from .data_generators import generate_hash_items
 
 
 def main() -> None:
@@ -16,7 +14,8 @@ def main() -> None:
         start_router=True,
         use_registry=True,
     )
-    cluster.router_client.put("reg1", "v1")
+    for key, value in generate_hash_items(10):
+        cluster.router_client.put(key, value)
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -1,16 +1,18 @@
-import os
-import time
-
 from api.main import app
 from database.replication import NodeCluster
 from .service_runner import start_frontend
+from .data_generators import generate_hash_items
 
 
 def main() -> None:
     app.router.on_startup.clear()
-    cluster = NodeCluster(base_path="/tmp/router_cluster", num_nodes=2, start_router=True)
-    cluster.router_client.put("r1", "v1")
-    cluster.router_client.put("r2", "v2")
+    cluster = NodeCluster(
+        base_path="/tmp/router_cluster",
+        num_nodes=2,
+        start_router=True,
+    )
+    for key, value in generate_hash_items(10):
+        cluster.router_client.put(key, value)
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")


### PR DESCRIPTION
## Summary
- expand data generation across example clusters
- document automatic workload generation in the READMEs

## Testing
- `pytest tests/test_lsm_db.py -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6867da4bf82083318db18c09d3d42876