### PR TITLE
Improve example outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ app/                 # Frontend web application
 
 Several small scripts under `examples/` start the cluster with different options. Each one launches the React UI in the background while the API runs in the foreground. Run them with `python examples/<file>.py` and visit the printed URLs.
 
-The scripts now populate the cluster using simple data generator functions so you can observe how each configuration behaves with a larger workload.
+The scripts now populate the cluster using simple data generator functions so you can observe how each configuration behaves with a larger workload. Each script prints the partition map and the placement of each generated record.
 
 - `hash_cluster.py` – three-node hash-partitioned cluster using LWW.
 - `range_cluster.py` – cluster with two explicit key ranges and sample composite keys.

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -908,6 +908,7 @@ curl "http://localhost:8000/data/query_index?field=color&value=red"
 - `examples/` – scripts de demonstração que geram dados automaticamente.
 
 Os exemplos inserem diversos registros aleatórios para demonstrar como cada configuração influencia a distribuição dos dados no cluster.
+Cada script exibe o mapa de partições e a localização de cada registro gerado.
 
 ## Executando os exemplos no Windows
 

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -16,10 +16,20 @@ def main() -> None:
         base_path="/tmp/hash_cluster",
         num_nodes=3,
         partition_strategy="hash",
+        replication_factor=2,
+        partitions_per_node=32,
         consistency_mode="lww",
     )
-    for key, value in generate_hash_items(20):
+
+    print("Partition map:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        print(f"  P{pid}: {owner}")
+
+    for key, value in generate_hash_items(50):
         cluster.put(0, key, value)
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        print(f"Stored {key} -> {value} in partition {pid} on {owner}")
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -13,8 +13,20 @@ def main() -> None:
         num_nodes=3,
         index_fields=["color"],
     )
-    for key, value in generate_index_items(20):
+
+    print("Partition map:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        print(f"  P{pid}: {owner}")
+
+    for key, value in generate_index_items(50):
         cluster.put(0, key, value)
+        color = json.loads(value)["color"]
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        idx_owner = cluster.get_index_owner("color", color)
+        print(
+            f"Stored {key} color={color} in partition {pid} on {owner}; index on {idx_owner}"
+        )
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -12,8 +12,19 @@ def main() -> None:
         num_nodes=3,
         key_ranges=ranges,
     )
-    for key, value in generate_range_items(20):
+
+    print("Partitions:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        rng = cluster.partitions[pid][0]
+        print(f"  P{pid} {rng} -> {owner}")
+
+    for key, value in generate_range_items(50):
         cluster.put(0, key, value)
+        pk = key.split("|", 1)[0]
+        pid = cluster.get_partition_id(pk)
+        owner = cluster.get_partition_map().get(pid)
+        rng = cluster.partitions[pid][0]
+        print(f"Stored {key} in partition {pid} {rng} on {owner}")
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -14,8 +14,20 @@ def main() -> None:
         start_router=True,
         use_registry=True,
     )
-    for key, value in generate_hash_items(10):
+
+    print("Partitions:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        rng = cluster.partitions[pid][0]
+        print(f"  P{pid} {rng} -> {owner}")
+
+    for key, value in generate_hash_items(50):
         cluster.router_client.put(key, value)
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        rng = cluster.partitions[pid][0]
+        print(
+            f"Router stored {key} -> {value} in partition {pid} {rng} on {owner}"
+        )
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -11,8 +11,16 @@ def main() -> None:
         num_nodes=2,
         start_router=True,
     )
-    for key, value in generate_hash_items(10):
+
+    print("Partition map:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        print(f"  P{pid}: {owner}")
+
+    for key, value in generate_hash_items(50):
         cluster.router_client.put(key, value)
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        print(f"Router stored {key} -> {value} in partition {pid} on {owner}")
     app.state.cluster = cluster
     front_proc = start_frontend()
     print("API running at http://localhost:8000")


### PR DESCRIPTION
## Summary
- expand example scripts
- show partition maps and item placement
- document logging in README files

## Testing
- `python -m pytest -q` *(fails: 3 failed, 150 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6867ec92c95c8331a938d49a5f032c77