### PR TITLE
Fix duplicate getTransactions export

### DIFF
--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -6,7 +6,6 @@ import {
   ClusterConfig,
   HotspotInfo,
   ReplicationStatus,
-  TransactionInfo,
   WALEntry,
   StorageEntry,
   SSTableInfo,
@@ -118,15 +117,6 @@ export const getReplicationStatus = async (): Promise<ReplicationStatus[]> => {
   return statuses;
 };
 
-export const getTransactions = async (): Promise<TransactionInfo[]> => {
-  const data = await fetchJson<{ transactions: { node: string; tx_ids: any[] }[] }>(
-    '/cluster/transactions',
-  );
-  return (data.transactions || []).map(t => ({
-    nodeId: t.node,
-    txIds: t.tx_ids || [],
-  }));
-};
 
 export const addNode = async (): Promise<string> => {
   const data = await fetchJson<{ status: string; node_id: string }>(

--- a/app/tests/transactions.test.ts
+++ b/app/tests/transactions.test.ts
@@ -6,6 +6,9 @@ describe('getTransactions', () => {
     const sample = { transactions: [ { node: 'n1', tx_ids: ['a', 'b'] } ] }
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => sample }))
     const res = await getTransactions()
-    expect(res).toEqual([{ nodeId: 'n1', txIds: ['a', 'b'] }])
+    expect(res).toEqual([
+      { node: 'n1', txId: 'a' },
+      { node: 'n1', txId: 'b' },
+    ])
   })
 })


### PR DESCRIPTION
## Summary
- remove duplicated TransactionInfo import
- delete older `getTransactions` implementation
- update transactions test to match flattened output

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6867fcd6fc9883319e844ad0b1556ce2