### PR TITLE
Add pagination support to records listing

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -402,8 +402,8 @@ def health() -> dict:
 
 
 @app.get("/data/records")
-def list_records_endpoint() -> dict:
-    """Return all records stored in the cluster."""
+def list_records_endpoint(offset: int = 0, limit: int | None = None) -> dict:
+    """Return records stored in the cluster with optional pagination."""
     cluster = app.state.cluster
     records = [
         {
@@ -411,7 +411,7 @@ def list_records_endpoint() -> dict:
             "clustering_key": ck,
             "value": val,
         }
-        for pk, ck, val in cluster.list_records()
+        for pk, ck, val in cluster.list_records(offset=offset, limit=limit)
     ]
     return {"records": records}
 

--- a/database/replication/replication.py
+++ b/database/replication/replication.py
@@ -1047,8 +1047,10 @@ class NodeCluster:
         db.close()
         return {k: [tpl for tpl in v if tpl[0] != TOMBSTONE] for k, v in merged.items()}
 
-    def list_records(self) -> list[tuple[str, str | None, object]]:
-        """Return all records currently stored across the cluster.
+    def list_records(
+        self, offset: int = 0, limit: int | None = None
+    ) -> list[tuple[str, str | None, object]]:
+        """Return records stored across the cluster with optional slicing.
 
         The method iterates over the known keys (``self._known_keys``). When the
         set is empty it loads the keys from disk for each node using
@@ -1073,7 +1075,10 @@ class NodeCluster:
                 continue
             records.append((pk, ck, value))
 
-        return records
+        if offset < 0:
+            offset = 0
+        end = offset + limit if limit is not None else None
+        return records[offset:end]
 
     def _move_hash_partition(self, pid: int, src: ClusterNode, dest: ClusterNode) -> None:
         items = self._load_node_items(src)

--- a/tests/api/test_data_records_api.py
+++ b/tests/api/test_data_records_api.py
@@ -46,3 +46,21 @@ def test_records_crud_and_scan():
         time.sleep(0.1)
         resp = client.get("/data/records")
         assert not any(r["partition_key"] == "alpha" and r["clustering_key"] == "a" for r in resp.json().get("records", []))
+
+
+def test_records_pagination():
+    with TestClient(app) as client:
+        for i in range(5):
+            resp = client.post(
+                "/data/records",
+                json={"partitionKey": f"pk{i}", "clusteringKey": None, "value": f"v{i}"},
+            )
+            assert resp.status_code == 200
+
+        time.sleep(0.1)
+        resp = client.get("/data/records", params={"offset": 2, "limit": 2})
+        assert resp.status_code == 200
+        data = resp.json().get("records", [])
+        assert len(data) == 2
+        assert data[0]["partition_key"] == "pk2"
+        assert data[1]["partition_key"] == "pk3"


### PR DESCRIPTION
## Summary
- add `offset` and `limit` parameters for listing records via API
- support optional slicing in `NodeCluster.list_records`
- cover pagination in data records API tests

## Testing
- `pytest -q tests/test_list_records.py tests/api/test_data_records_api.py`
- `pytest -q` *(fails: ValueError during compaction)*

------
https://chatgpt.com/codex/tasks/task_e_686806ddd9f08331977d92f282d2a976