### PR TITLE
Add pagination to storage inspector endpoints

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -319,8 +319,8 @@ def node_replication_status(node_id: str) -> dict:
 
 
 @app.get("/nodes/{node_id}/wal")
-def node_wal(node_id: str) -> dict:
-    """Return Write Ahead Log entries stored on ``node_id``."""
+def node_wal(node_id: str, offset: int = 0, limit: int | None = None) -> dict:
+    """Return Write Ahead Log entries stored on ``node_id`` with optional pagination."""
     cluster = app.state.cluster
     node = cluster.nodes_by_id.get(node_id)
     if node is None:
@@ -336,14 +336,17 @@ def node_wal(node_id: str) -> dict:
             }
             for e in entries
         ]
-        return {"entries": results}
+        if offset < 0:
+            offset = 0
+        end = offset + limit if limit is not None else None
+        return {"entries": results[offset:end]}
     except Exception:
         raise HTTPException(status_code=503, detail="unreachable")
 
 
 @app.get("/nodes/{node_id}/memtable")
-def node_memtable(node_id: str) -> dict:
-    """Return current MemTable contents for ``node_id``."""
+def node_memtable(node_id: str, offset: int = 0, limit: int | None = None) -> dict:
+    """Return current MemTable contents for ``node_id`` with optional pagination."""
     cluster = app.state.cluster
     node = cluster.nodes_by_id.get(node_id)
     if node is None:
@@ -358,7 +361,10 @@ def node_memtable(node_id: str) -> dict:
             }
             for e in entries
         ]
-        return {"entries": results}
+        if offset < 0:
+            offset = 0
+        end = offset + limit if limit is not None else None
+        return {"entries": results[offset:end]}
     except Exception:
         raise HTTPException(status_code=503, detail="unreachable")
 

--- a/tests/api/test_storage_inspector_api.py
+++ b/tests/api/test_storage_inspector_api.py
@@ -48,3 +48,35 @@ def test_storage_inspector_endpoints():
         if data["tables"]:
             table = data["tables"][0]
             assert "id" in table and "level" in table and "item_count" in table
+
+
+def test_storage_inspector_pagination():
+    with TestClient(app) as client:
+        nodes_resp = client.get("/cluster/nodes")
+        assert nodes_resp.status_code == 200
+        node_id = nodes_resp.json()["nodes"][0]["node_id"]
+
+        for i in range(5):
+            client.post(f"/put/inspector_page{i}", params={"value": str(i)})
+
+        resp_all = client.get(f"/nodes/{node_id}/wal")
+        assert resp_all.status_code in {200, 503}
+        if resp_all.status_code == 200:
+            entries = resp_all.json().get("entries", [])
+            resp = client.get(
+                f"/nodes/{node_id}/wal",
+                params={"offset": 1, "limit": 2},
+            )
+            assert resp.status_code == 200
+            assert resp.json().get("entries") == entries[1:3]
+
+        resp_all = client.get(f"/nodes/{node_id}/memtable")
+        assert resp_all.status_code in {200, 503}
+        if resp_all.status_code == 200:
+            entries = resp_all.json().get("entries", [])
+            resp = client.get(
+                f"/nodes/{node_id}/memtable",
+                params={"offset": 1, "limit": 2},
+            )
+            assert resp.status_code == 200
+            assert resp.json().get("entries") == entries[1:3]


### PR DESCRIPTION
## Summary
- enable `offset` and `limit` parameters on `/nodes/{node_id}/wal` and `/nodes/{node_id}/memtable`
- test pagination for storage inspector API endpoints

## Testing
- `pytest tests/api/test_storage_inspector_api.py::test_storage_inspector_pagination -q`
- `pytest -q` *(fails: TransactionTest and VectorClockMergeTest)*

------
https://chatgpt.com/codex/tasks/task_e_68680cb7a8d08331b9f7be3d7c497a36