### PR TITLE
Add pagination params to storage service

### DIFF
--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -154,9 +154,17 @@ export const startNode = async (nodeId: string): Promise<Node> => {
   return node;
 };
 
-export const getWalEntries = async (nodeId: string): Promise<WALEntry[]> => {
+export const getWalEntries = async (
+  nodeId: string,
+  offset = 0,
+  limit = 50,
+): Promise<WALEntry[]> => {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
   const data = await fetchJson<{ entries: any[] }>(
-    `/nodes/${encodeURIComponent(nodeId)}/wal`,
+    `/nodes/${encodeURIComponent(nodeId)}/wal?${params.toString()}`,
   );
   return (data.entries || []).map(e => ({
     type: e.type,
@@ -168,9 +176,15 @@ export const getWalEntries = async (nodeId: string): Promise<WALEntry[]> => {
 
 export const getMemtableEntries = async (
   nodeId: string,
+  offset = 0,
+  limit = 50,
 ): Promise<StorageEntry[]> => {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
   const data = await fetchJson<{ entries: any[] }>(
-    `/nodes/${encodeURIComponent(nodeId)}/memtable`,
+    `/nodes/${encodeURIComponent(nodeId)}/memtable?${params.toString()}`,
   );
   return (data.entries || []).map(e => ({
     key: e.key,

--- a/app/services/databaseService.ts
+++ b/app/services/databaseService.ts
@@ -1,8 +1,15 @@
 import { UserRecord } from '../types';
 import { fetchJson } from './request';
 
-export const getUserRecords = async (): Promise<UserRecord[]> => {
-  const data = await fetchJson<{ records: { partition_key: string; clustering_key: string | null; value: string }[] }>('/data/records');
+export const getUserRecords = async (
+  offset = 0,
+  limit = 50,
+): Promise<UserRecord[]> => {
+  const params = new URLSearchParams({
+    offset: String(offset),
+    limit: String(limit),
+  });
+  const data = await fetchJson<{ records: { partition_key: string; clustering_key: string | null; value: string }[] }>(`/data/records?${params.toString()}`);
   return data.records.map(r => ({
     partitionKey: r.partition_key,
     clusteringKey: r.clustering_key ?? undefined,

--- a/app/services/storageService.ts
+++ b/app/services/storageService.ts
@@ -6,12 +6,23 @@ export const getClusterConfig = (): Promise<ClusterConfig> => api.getClusterConf
 export const getHotspots = (): Promise<HotspotInfo> => api.getHotspots();
 export const getReplicationStatus = (): Promise<ReplicationStatus[]> => api.getReplicationStatus();
 
-export const getWalEntries = (nodeId: string): Promise<WALEntry[]> => api.getWalEntries(nodeId);
-export const getMemtableEntries = (nodeId: string): Promise<StorageEntry[]> => api.getMemtableEntries(nodeId);
+export const getWalEntries = (
+  nodeId: string,
+  offset = 0,
+  limit = 50,
+): Promise<WALEntry[]> => api.getWalEntries(nodeId, offset, limit);
+export const getMemtableEntries = (
+  nodeId: string,
+  offset = 0,
+  limit = 50,
+): Promise<StorageEntry[]> => api.getMemtableEntries(nodeId, offset, limit);
 export const getSstables = (nodeId: string): Promise<SSTableInfo[]> => api.getSstables(nodeId);
 export const getSstableEntries = (nodeId: string, sstableId: string): Promise<StorageEntry[]> => api.getSstableEntries(nodeId, sstableId);
 
-export const getUserRecords = (): Promise<UserRecord[]> => db.getUserRecords();
+export const getUserRecords = (
+  offset = 0,
+  limit = 50,
+): Promise<UserRecord[]> => db.getUserRecords(offset, limit);
 export const saveUserRecord = (record: UserRecord): Promise<UserRecord> => db.saveUserRecord(record);
 export const deleteUserRecord = (partitionKey: string, clusteringKey: string): Promise<void> => db.deleteUserRecord(partitionKey, clusteringKey);
 


### PR DESCRIPTION
## Summary
- support `offset` and `limit` arguments when fetching records, WAL entries and MemTable entries
- default to `offset=0` and `limit=50`
- re-export new signatures via `storageService`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: KeyboardInterrupt after 131 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68680ef970408331b64058f65167dcf6