### PR TITLE
Add pagination feature to DataBrowser

### DIFF
--- a/app/components/databrowser/Pagination.tsx
+++ b/app/components/databrowser/Pagination.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import Button from '../common/Button';
+
+interface PaginationProps {
+  currentPage: number;
+  onPageChange: (page: number) => void;
+  disablePrev?: boolean;
+  disableNext?: boolean;
+}
+
+const Pagination: React.FC<PaginationProps> = ({ currentPage, onPageChange, disablePrev, disableNext }) => {
+  const goPrev = () => onPageChange(currentPage - 1);
+  const goNext = () => onPageChange(currentPage + 1);
+
+  return (
+    <div className="flex justify-center space-x-2 mt-4">
+      <Button variant="secondary" size="sm" onClick={goPrev} disabled={disablePrev}>Previous</Button>
+      <span className="text-green-200 self-center">Page {currentPage}</span>
+      <Button variant="secondary" size="sm" onClick={goNext} disabled={disableNext}>Next</Button>
+    </div>
+  );
+};
+
+export default Pagination;


### PR DESCRIPTION
## Summary
- add `Pagination` component with prev/next controls
- track current page state in `DataBrowser` and fetch page slices
- show pagination controls below the table
- test record pagination in `DataBrowser` tests

## Testing
- `npm --prefix app test`

------
https://chatgpt.com/codex/tasks/task_e_6868117c5938833196e8c4fa93137ba1