### PR TITLE
Implement pagination in WAL and MemTable views

### DIFF
--- a/app/components/management/StorageInspector.tsx
+++ b/app/components/management/StorageInspector.tsx
@@ -30,16 +30,27 @@ const LoadingSpinner: React.FC = () => (
     </div>
 );
 
-const WALView: React.FC<{nodeId: string}> = ({ nodeId }) => {
+export const WALView: React.FC<{nodeId: string}> = ({ nodeId }) => {
     const [entries, setEntries] = useState<WALEntry[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [pageSize, setPageSize] = useState(50);
 
-    useEffect(() => {
-        getWalEntries(nodeId).then(data => {
+    const loadData = useCallback(() => {
+        setIsLoading(true);
+        getWalEntries(nodeId, (currentPage - 1) * pageSize, pageSize).then(data => {
             setEntries(data);
             setIsLoading(false);
         });
+    }, [nodeId, currentPage, pageSize]);
+
+    useEffect(() => {
+        setCurrentPage(1);
     }, [nodeId]);
+
+    useEffect(() => {
+        loadData();
+    }, [loadData]);
 
     if (isLoading) return <LoadingSpinner />;
 
@@ -66,20 +77,48 @@ const WALView: React.FC<{nodeId: string}> = ({ nodeId }) => {
                 </tbody>
             </table>
             {entries.length === 0 && <p className="p-4 text-center text-green-400">WAL is empty.</p>}
+            <div className="flex items-center justify-center space-x-2 mt-2">
+                <button
+                    className="px-2 py-1 bg-green-900/40 rounded disabled:opacity-50"
+                    disabled={currentPage === 1}
+                    onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                >
+                    Prev
+                </button>
+                <span className="text-sm">Page {currentPage}</span>
+                <button
+                    className="px-2 py-1 bg-green-900/40 rounded disabled:opacity-50"
+                    disabled={entries.length < pageSize}
+                    onClick={() => setCurrentPage(p => p + 1)}
+                >
+                    Next
+                </button>
+            </div>
         </div>
     );
 };
 
-const MemTableView: React.FC<{nodeId: string}> = ({ nodeId }) => {
+export const MemTableView: React.FC<{nodeId: string}> = ({ nodeId }) => {
     const [entries, setEntries] = useState<StorageEntry[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const [currentPage, setCurrentPage] = useState(1);
+    const [pageSize, setPageSize] = useState(50);
 
-    useEffect(() => {
-        getMemtableEntries(nodeId).then(data => {
+    const loadData = useCallback(() => {
+        setIsLoading(true);
+        getMemtableEntries(nodeId, (currentPage - 1) * pageSize, pageSize).then(data => {
             setEntries(data);
             setIsLoading(false);
         });
+    }, [nodeId, currentPage, pageSize]);
+
+    useEffect(() => {
+        setCurrentPage(1);
     }, [nodeId]);
+
+    useEffect(() => {
+        loadData();
+    }, [loadData]);
 
     if (isLoading) return <LoadingSpinner />;
 
@@ -102,6 +141,23 @@ const MemTableView: React.FC<{nodeId: string}> = ({ nodeId }) => {
                 </tbody>
             </table>
             {entries.length === 0 && <p className="p-4 text-center text-green-400">MemTable is empty.</p>}
+            <div className="flex items-center justify-center space-x-2 mt-2">
+                <button
+                    className="px-2 py-1 bg-green-900/40 rounded disabled:opacity-50"
+                    disabled={currentPage === 1}
+                    onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                >
+                    Prev
+                </button>
+                <span className="text-sm">Page {currentPage}</span>
+                <button
+                    className="px-2 py-1 bg-green-900/40 rounded disabled:opacity-50"
+                    disabled={entries.length < pageSize}
+                    onClick={() => setCurrentPage(p => p + 1)}
+                >
+                    Next
+                </button>
+            </div>
         </div>
     );
 };

--- a/app/tests/StorageInspectorPagination.test.tsx
+++ b/app/tests/StorageInspectorPagination.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+vi.mock('../services/api', () => ({
+  getWalEntries: vi.fn(),
+  getMemtableEntries: vi.fn(),
+}))
+
+import { WALView, MemTableView } from '../components/management/StorageInspector'
+import { getWalEntries, getMemtableEntries } from '../services/api'
+
+const pageItems = Array.from({ length: 50 }, (_, i) => ({
+  type: 'PUT',
+  key: `k${i}`,
+  value: `v${i}`,
+  vectorClock: {},
+}))
+
+const memItems = Array.from({ length: 50 }, (_, i) => ({
+  key: `k${i}`,
+  value: `v${i}`,
+  vectorClock: {},
+}))
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ;(getWalEntries as any).mockResolvedValue(pageItems)
+  ;(getMemtableEntries as any).mockResolvedValue(memItems)
+})
+
+describe('WALView pagination', () => {
+  it('requests next and previous pages', async () => {
+    render(<WALView nodeId="n1" />)
+    await waitFor(() => {
+      expect(getWalEntries).toHaveBeenCalledWith('n1', 0, 50)
+    })
+
+    ;(getWalEntries as any).mockResolvedValue([])
+    fireEvent.click(screen.getByText('Next'))
+    await waitFor(() => {
+      expect(getWalEntries).toHaveBeenLastCalledWith('n1', 50, 50)
+    })
+
+    ;(getWalEntries as any).mockResolvedValue([])
+    fireEvent.click(screen.getByText('Prev'))
+    await waitFor(() => {
+      expect(getWalEntries).toHaveBeenLastCalledWith('n1', 0, 50)
+    })
+  })
+})
+
+describe('MemTableView pagination', () => {
+  it('requests next page', async () => {
+    render(<MemTableView nodeId="n1" />)
+    await waitFor(() => {
+      expect(getMemtableEntries).toHaveBeenCalledWith('n1', 0, 50)
+    })
+
+    ;(getMemtableEntries as any).mockResolvedValue([])
+    fireEvent.click(screen.getByText('Next'))
+    await waitFor(() => {
+      expect(getMemtableEntries).toHaveBeenLastCalledWith('n1', 50, 50)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- export WALView and MemTableView components
- add currentPage/pageSize state and pagination buttons
- load entries with offset/limit
- test pagination interactions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68681186840883318e2f6e699c5a246d