### PR TITLE
Update README docs for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The REST server offers simple endpoints to manage data stored in the cluster.
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
-| `GET` | `/data/records` | List all records in the cluster |
+| `GET` | `/data/records` | List all records in the cluster (optional `offset` and `limit` query params) |
 | `POST` | `/data/records` | Insert a new record using a JSON body |
 | `PUT` | `/data/records/{partition_key}/{clustering_key}` | Update an existing record (send `value` as query param) |
 | `DELETE` | `/data/records/{partition_key}/{clustering_key}` | Remove a record |
@@ -173,6 +173,16 @@ curl -X DELETE http://localhost:8000/data/records/alpha/a
 curl "http://localhost:8000/data/query_index?field=color&value=red"
 # {"keys": ["p1"]}
 ```
+
+### Storage inspection API
+
+These endpoints expose internal storage data from individual nodes.
+
+| Method | Path | Description |
+| ------ | ---- | ----------- |
+| `GET` | `/nodes/{id}/wal` | List WAL entries (optional `offset` and `limit` query params) |
+| `GET` | `/nodes/{id}/memtable` | List MemTable contents (optional `offset` and `limit` query params) |
+| `GET` | `/nodes/{id}/sstables` | Show SSTable metadata |
 
 ### Cluster actions API
 

--- a/app/README.md
+++ b/app/README.md
@@ -43,3 +43,7 @@ Preview the built app locally with:
 ```bash
 npm run preview
 ```
+
+## Pagination controls
+
+The storage inspector lists WAL and MemTable entries in pages of 50 items. Use the Next and Prev buttons to navigate through results. These controls adjust the `offset` and `limit` query parameters sent to the backend.


### PR DESCRIPTION
## Summary
- document optional offset and limit query parameters in `/data/records`
- add storage inspection API table listing `/nodes/{id}/wal` and `/nodes/{id}/memtable` with pagination info
- explain pagination controls briefly in the frontend README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pytest -q` *(fails: KeyboardInterrupt after completion)*

------
https://chatgpt.com/codex/tasks/task_e_6868118a21dc8331be3b6fb9fe6f099e