### PR TITLE
Ensure tests pass

### DIFF
--- a/database/lsm/sstable.py
+++ b/database/lsm/sstable.py
@@ -110,6 +110,8 @@ class SSTableManager:
         sstable_filename = f"sstable_{timestamp}.txt"
         sstable_path = os.path.join(self.sstable_dir, sstable_filename)
 
+        os.makedirs(self.sstable_dir, exist_ok=True)
+
         with open(sstable_path, "w", encoding="utf-8") as f:
             for key, value, vector in sorted_items:
                 entry = {"key": key, "value": value, "vector": vector.clock}

--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -547,7 +547,11 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
                                 if self._node.write_locks.get(k) == request.tx_id:
                                     self._node.write_locks.pop(k, None)
                     raise RuntimeError("Conflict")
+        ops_by_key = {}
         for op, req in ops:
+            ops_by_key[req.key] = (op, req)
+
+        for op, req in ops_by_key.values():
             if op == "put":
                 new_vc = (
                     VectorClock(dict(req.vector.items))

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -92,7 +92,7 @@ class TransactionTest(unittest.TestCase):
                 t.join()
 
             with node._tx_lock:
-                self.assertEqual(len(node.active_transactions[tx_id]), 10)
+                self.assertEqual(len(node.active_transactions[tx_id]["ops"]), 10)
 
             service.CommitTransaction(
                 replication_pb2.TransactionControl(tx_id=tx_id), None
@@ -541,9 +541,9 @@ class TransactionTest(unittest.TestCase):
             t1.join()
             t2.join()
 
-        self.assertEqual(node.db.get("cnt"), "2")
+            self.assertEqual(node.db.get("cnt"), "2")
 
-        node.db.close()
+            node.db.close()
 
     def test_snapshot_isolation_detects_lost_update(self):
         """Snapshot isolation should abort conflicting updates automatically."""

--- a/tests/test_vector_clock.py
+++ b/tests/test_vector_clock.py
@@ -21,7 +21,7 @@ class VectorClockMergeTest(unittest.TestCase):
 
             records = db.get_record('k')
             self.assertEqual(len(records), 2)
-            values = sorted(v for v, _ in records)
+            values = sorted(v for v, *_ in records)
             self.assertEqual(values, ['va', 'vb'])
 
             vc_merge = VectorClock({'A': 1, 'B': 1})


### PR DESCRIPTION
## Summary
- ensure SSTable directory exists before writing
- avoid duplicates when committing a transaction
- fix transactional tests
- fix vector clock test expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686817e32ba08331ba425228b5d1c9e7