### PR TITLE
Add thread-safe EventLogger

### DIFF
--- a/database/replication/replication.py
+++ b/database/replication/replication.py
@@ -30,6 +30,7 @@ from ..utils.vector_clock import VectorClock
 from ..lsm.lsm_db import _merge_version_lists, SimpleLSMDB
 from ..lsm.sstable import TOMBSTONE
 
+from ..utils.event_logger import EventLogger
 
 DEFAULT_NUM_PARTITIONS = 128
 
@@ -93,6 +94,10 @@ class NodeCluster:
         if os.path.exists(base_path):
             shutil.rmtree(base_path)
         os.makedirs(base_path)
+
+        # Initialize event logger for cluster operations
+        self.event_logger = EventLogger(os.path.join(base_path, "event_log.txt"))
+        self.event_logger.log("NodeCluster created")
 
         base_port = 9000
         self.base_port = base_port

--- a/database/utils/__init__.py
+++ b/database/utils/__init__.py
@@ -3,3 +3,4 @@ from .lamport import LamportClock
 from .merkle import compute_segment_hashes
 from .consistency import Consistency
 from .crdt import GCounter
+from .event_logger import EventLogger

--- a/database/utils/event_logger.py
+++ b/database/utils/event_logger.py
@@ -1,0 +1,19 @@
+import os
+import time
+import threading
+
+class EventLogger:
+    """Thread-safe event logger writing timestamped messages to a file."""
+
+    def __init__(self, log_path: str) -> None:
+        self.log_path = log_path
+        self._lock = threading.Lock()
+        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        self._fp = open(log_path, "a", encoding="utf-8")
+
+    def log(self, message: str) -> None:
+        """Append ``message`` to the log file with timestamp."""
+        timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+        with self._lock:
+            self._fp.write(f"[{timestamp}] {message}\n")
+            self._fp.flush()


### PR DESCRIPTION
## Summary
- add a new EventLogger utility for timestamped logging
- expose EventLogger in utils package
- integrate EventLogger into NodeCluster and log cluster creation

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Fatal Python error during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68685d2bab9483318171185514d69f81