### PR TITLE
Log partition transfers with event logger

### DIFF
--- a/database/replication/replication.py
+++ b/database/replication/replication.py
@@ -1025,7 +1025,7 @@ class NodeCluster:
                     expected = bytes_copied / float(self.max_transfer_rate)
                     if expected > elapsed:
                         time.sleep(expected - elapsed)
-        print(
+        self.event_logger.log(
             f"moved partition {partition_id} from {src_node.node_id} to {dst_node.node_id}"
         )
 


### PR DESCRIPTION
## Summary
- use `self.event_logger.log` when partitions move

## Testing
- `pytest -k transfer_partition -q`

------
https://chatgpt.com/codex/tasks/task_e_68686d49a40c8331854b7098368ffb34