### PR TITLE
Add event logging on node removal

### DIFF
--- a/database/replication/replication.py
+++ b/database/replication/replication.py
@@ -1283,6 +1283,7 @@ class NodeCluster:
                 self.partitions = self.partitioner.partitions
 
         self.nodes_by_id.pop(node_id)
+        self.event_logger.log(f"Node {node_id} removido do cluster.")
         self.update_partition_map()
         node.stop()
 


### PR DESCRIPTION
## Summary
- log node removal in `NodeCluster.remove_node`

## Testing
- `pytest tests/test_virtual_node_rebalance.py::VirtualNodeRebalanceTest::test_remove_node_virtual_nodes -q`
- `pytest tests/test_rebalance.py::RebalanceHashClusterTest::test_remove_node_rebalances -q`


------
https://chatgpt.com/codex/tasks/task_e_68686d5270e08331aaae29d6d6f31a65