### PR TITLE
Add logs for automatic management events

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -282,7 +282,7 @@ def merge_partitions(pid1: int, pid2: int) -> dict:
 def rebalance() -> dict:
     """Re-send the current partition map to all nodes."""
     cluster = app.state.cluster
-    cluster.update_partition_map()
+    cluster.update_partition_map(manual=True)
     return {"status": "ok"}
 
 


### PR DESCRIPTION
## Summary
- log hot key marking with optional migration info
- log automatic split & merge actions when managing hot/cold partitions
- log manual rebalance intent

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68686fd99ef083319da78075f084831e