### PR TITLE
Add event log endpoint

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -176,6 +176,14 @@ def time_series_metrics() -> dict:
     return data
 
 
+@app.get("/cluster/events")
+def cluster_events(offset: int = 0, limit: int | None = None) -> dict:
+    """Return recent event log entries."""
+    cluster = app.state.cluster
+    events = cluster.event_logger.get_events(offset=offset, limit=limit)
+    return {"events": events}
+
+
 @app.get("/cluster/config")
 def cluster_config() -> dict:
     """Return cluster configuration values."""

--- a/database/utils/event_logger.py
+++ b/database/utils/event_logger.py
@@ -1,19 +1,36 @@
 import os
 import time
 import threading
+from collections import deque
 
 class EventLogger:
-    """Thread-safe event logger writing timestamped messages to a file."""
+    """Thread-safe event logger writing timestamped messages to a file.
 
-    def __init__(self, log_path: str) -> None:
+    In addition to persisting events to disk, the logger keeps the most
+    recent messages in memory so they can be served quickly via the API.
+    """
+
+    def __init__(self, log_path: str, *, max_events: int = 1000) -> None:
         self.log_path = log_path
         self._lock = threading.Lock()
+        self._events = deque(maxlen=max_events)
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         self._fp = open(log_path, "a", encoding="utf-8")
 
     def log(self, message: str) -> None:
         """Append ``message`` to the log file with timestamp."""
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+        entry = f"[{timestamp}] {message}"
         with self._lock:
-            self._fp.write(f"[{timestamp}] {message}\n")
+            self._fp.write(entry + "\n")
             self._fp.flush()
+            self._events.append(entry)
+
+    def get_events(self, offset: int = 0, limit: int | None = None) -> list[str]:
+        """Return recent log entries stored in memory."""
+        with self._lock:
+            entries = list(self._events)
+        if offset < 0:
+            offset = 0
+        end = offset + limit if limit is not None else None
+        return entries[offset:end]

--- a/tests/api/test_event_log_api.py
+++ b/tests/api/test_event_log_api.py
@@ -1,0 +1,16 @@
+import os
+import sys
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+from api.main import app
+
+
+def test_event_log_endpoint_returns_events():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/events")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "events" in data
+        assert isinstance(data["events"], list)
+        assert any("NodeCluster created" in e for e in data["events"])


### PR DESCRIPTION
## Summary
- support in-memory log storage for EventLogger
- expose recent events in new `/cluster/events` endpoint
- test the new endpoint

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68687356e1b88331b2e53f20076a0cea