### PR TITLE
Add per-node event logs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -401,6 +401,17 @@ def node_sstables(node_id: str) -> dict:
         raise HTTPException(status_code=503, detail="unreachable")
 
 
+@app.get("/nodes/{node_id}/events")
+def node_events(node_id: str, offset: int = 0, limit: int | None = None) -> dict:
+    """Return recent event log entries for ``node_id``."""
+    cluster = app.state.cluster
+    logger = cluster.node_loggers.get(node_id)
+    if logger is None:
+        raise HTTPException(status_code=404, detail="node not found")
+    events = logger.get_events(offset=offset, limit=limit)
+    return {"events": events}
+
+
 @app.get("/health")
 def health() -> dict:
     """Return basic cluster information."""

--- a/database/utils/event_logger.py
+++ b/database/utils/event_logger.py
@@ -17,6 +17,11 @@ class EventLogger:
         os.makedirs(os.path.dirname(log_path), exist_ok=True)
         self._fp = open(log_path, "a", encoding="utf-8")
 
+    def close(self) -> None:
+        """Close the underlying log file."""
+        with self._lock:
+            self._fp.close()
+
     def log(self, message: str) -> None:
         """Append ``message`` to the log file with timestamp."""
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())


### PR DESCRIPTION
## Summary
- introduce `EventLogger.close()` helper
- track `node_loggers` in `NodeCluster` and initialize per-node logs
- pass the logger to each node on start/add/restart and clean it up when removed
- expose `/nodes/{node_id}/events` endpoint

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_68687ec7f71c8331b9e1c52dd90b03e2