### PR TITLE
Add node specific event logs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -184,6 +184,16 @@ def cluster_events(offset: int = 0, limit: int | None = None) -> dict:
     return {"events": events}
 
 
+@app.get("/cluster/nodes/{node_id}/events")
+def node_events(node_id: str, offset: int = 0, limit: int | None = None) -> dict:
+    """Return recent event log entries for a specific node."""
+    cluster = app.state.cluster
+    events = cluster.get_node_events(node_id, offset=offset, limit=limit)
+    if not events and node_id not in cluster.nodes_by_id:
+        raise HTTPException(status_code=404, detail="Node not found")
+    return {"events": events}
+
+
 @app.get("/cluster/config")
 def cluster_config() -> dict:
     """Return cluster configuration values."""

--- a/database/utils/event_logger.py
+++ b/database/utils/event_logger.py
@@ -34,3 +34,8 @@ class EventLogger:
             offset = 0
         end = offset + limit if limit is not None else None
         return entries[offset:end]
+
+    def close(self) -> None:
+        """Close the underlying file handle."""
+        with self._lock:
+            self._fp.close()

--- a/tests/api/test_event_log_api.py
+++ b/tests/api/test_event_log_api.py
@@ -14,3 +14,12 @@ def test_event_log_endpoint_returns_events():
         assert "events" in data
         assert isinstance(data["events"], list)
         assert any("NodeCluster created" in e for e in data["events"])
+
+
+def test_node_event_log_endpoint_returns_events():
+    with TestClient(app) as client:
+        resp = client.get("/cluster/nodes/node_0/events")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "events" in data
+        assert isinstance(data["events"], list)


### PR DESCRIPTION
## Summary
- give each node a dedicated event logger
- expose node events via new API endpoint
- keep cluster logger and close file handles on shutdown
- include basic tests for node event endpoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest tests/api/test_event_log_api.py::test_event_log_endpoint_returns_events -q`
- `pytest tests/api/test_event_log_api.py::test_node_event_log_endpoint_returns_events -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68687ec7f71c8331b9e1c52dd90b03e2