### PR TITLE
Add log viewer component and API helpers

### DIFF
--- a/app/App.tsx
+++ b/app/App.tsx
@@ -5,8 +5,9 @@ import DataBrowser from './components/DataBrowser';
 import Transactions from './components/Transactions';
 import Management from './components/Management';
 import ClusterInternals from './components/ClusterInternals';
+import LogViewer from './components/internals/LogViewer';
 
-type View = 'dashboard' | 'browser' | 'transactions' | 'management' | 'internals';
+type View = 'dashboard' | 'browser' | 'transactions' | 'management' | 'internals' | 'logs';
 
 const App: React.FC = () => {
   const [activeView, setActiveView] = useState<View>('dashboard');
@@ -34,6 +35,8 @@ const App: React.FC = () => {
         return <Transactions />;
       case 'internals':
         return <ClusterInternals />;
+      case 'logs':
+        return <LogViewer />;
       case 'management':
         return <Management initialSelectedNodeId={managedNodeId} />;
       default:

--- a/app/README.md
+++ b/app/README.md
@@ -47,3 +47,7 @@ npm run preview
 ## Pagination controls
 
 The storage inspector lists WAL and MemTable entries in pages of 50 items. Use the Next and Prev buttons to navigate through results. These controls adjust the `offset` and `limit` query parameters sent to the backend.
+
+## Viewing logs
+
+Select **Logs** from the sidebar to inspect recent cluster or node events. Use the dropdown to switch between overall cluster logs and individual node logs.

--- a/app/components/ClusterInternals.tsx
+++ b/app/components/ClusterInternals.tsx
@@ -2,9 +2,10 @@ import React, { useState } from 'react';
 import ConfigurationView from './internals/ConfigurationView';
 import HotspotsView from './internals/HotspotsView';
 import ReplicationStatusView from './internals/ReplicationStatusView';
+import LogViewer from './internals/LogViewer';
 import Card from './common/Card';
 
-type InternalsTab = 'config' | 'hotspots' | 'replication';
+type InternalsTab = 'config' | 'hotspots' | 'replication' | 'logs';
 
 const TabButton: React.FC<{
     label: string;
@@ -33,6 +34,8 @@ const ClusterInternals: React.FC = () => {
                 return <HotspotsView />;
             case 'replication':
                 return <ReplicationStatusView />;
+            case 'logs':
+                return <LogViewer />;
             default:
                 return null;
         }
@@ -42,7 +45,7 @@ const ClusterInternals: React.FC = () => {
     <div className="space-y-6">
        <div>
         <h1 className="text-3xl font-bold text-white">Cluster Internals</h1>
-        <p className="text-green-300 mt-1">Observe the internal configuration, performance hotspots, and replication state.</p>
+        <p className="text-green-300 mt-1">Observe the internal configuration, performance hotspots, replication state, and logs.</p>
       </div>
 
       <Card className="p-2">
@@ -50,6 +53,7 @@ const ClusterInternals: React.FC = () => {
             <TabButton label="Configuration" isActive={activeTab === 'config'} onClick={() => setActiveTab('config')} />
             <TabButton label="Hotspots" isActive={activeTab === 'hotspots'} onClick={() => setActiveTab('hotspots')} />
             <TabButton label="Replication Status" isActive={activeTab === 'replication'} onClick={() => setActiveTab('replication')} />
+            <TabButton label="Logs" isActive={activeTab === 'logs'} onClick={() => setActiveTab('logs')} />
         </div>
       </Card>
 

--- a/app/components/Sidebar.tsx
+++ b/app/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ICONS } from '../constants';
 
-type View = 'dashboard' | 'browser' | 'transactions' | 'management' | 'internals';
+type View = 'dashboard' | 'browser' | 'transactions' | 'management' | 'internals' | 'logs';
 
 interface SidebarProps {
   activeView: View;
@@ -60,6 +60,12 @@ const Sidebar: React.FC<SidebarProps> = ({ activeView, setActiveView }) => {
           label="Cluster Internals"
           isActive={activeView === 'internals'}
           onClick={() => setActiveView('internals')}
+        />
+        <NavItem
+          icon={ICONS.browser}
+          label="Logs"
+          isActive={activeView === 'logs'}
+          onClick={() => setActiveView('logs')}
         />
         <div className="border-t border-green-900/50 my-4"></div>
          <NavItem

--- a/app/components/internals/LogViewer.tsx
+++ b/app/components/internals/LogViewer.tsx
@@ -1,0 +1,72 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { getNodes, getClusterEvents, getNodeEvents } from '../../services/api';
+import { Node } from '../../types';
+import Card from '../common/Card';
+import Button from '../common/Button';
+
+const LogViewer: React.FC = () => {
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [selected, setSelected] = useState<string>('cluster');
+  const [events, setEvents] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const fetchEvents = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const data =
+        selected === 'cluster'
+          ? await getClusterEvents()
+          : await getNodeEvents(selected);
+      setEvents(data);
+    } catch (err) {
+      console.error('Failed to fetch events', err);
+      setEvents([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selected]);
+
+  useEffect(() => {
+    getNodes().then(setNodes).catch(err => console.error(err));
+  }, []);
+
+  useEffect(() => {
+    fetchEvents();
+  }, [fetchEvents]);
+
+  return (
+    <Card>
+      <div className="p-4 border-b border-green-800/60 flex items-center space-x-2">
+        <h3 className="text-lg font-semibold text-green-100 flex-1">Event Logs</h3>
+        <select
+          value={selected}
+          onChange={e => setSelected(e.target.value)}
+          className="bg-[#10180f] border border-green-700/50 rounded-md px-2 py-1 text-green-200"
+        >
+          <option value="cluster">Cluster</option>
+          {nodes.map(n => (
+            <option key={n.id} value={n.id}>{n.id}</option>
+          ))}
+        </select>
+        <Button size="sm" variant="secondary" onClick={fetchEvents}>
+          Refresh
+        </Button>
+      </div>
+      <div className="p-4 max-h-96 overflow-y-auto font-mono text-sm bg-[#10180f]">
+        {isLoading ? (
+          <div className="text-center">Loading...</div>
+        ) : events.length > 0 ? (
+          <ul className="space-y-1">
+            {events.map((e, i) => (
+              <li key={i}>{e}</li>
+            ))}
+          </ul>
+        ) : (
+          <div className="text-center text-green-400">No events found.</div>
+        )}
+      </div>
+    </Card>
+  );
+};
+
+export default LogViewer;

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -298,3 +298,30 @@ export const abortTransaction = async (
     { method: 'POST' },
   );
 };
+
+export const getClusterEvents = async (
+  offset = 0,
+  limit?: number,
+): Promise<string[]> => {
+  const params = new URLSearchParams();
+  if (offset) params.append('offset', String(offset));
+  if (typeof limit === 'number') params.append('limit', String(limit));
+  const qs = params.size ? `?${params.toString()}` : '';
+  const data = await fetchJson<{ events: string[] }>(`/cluster/events${qs}`);
+  return data.events || [];
+};
+
+export const getNodeEvents = async (
+  nodeId: string,
+  offset = 0,
+  limit?: number,
+): Promise<string[]> => {
+  const params = new URLSearchParams();
+  if (offset) params.append('offset', String(offset));
+  if (typeof limit === 'number') params.append('limit', String(limit));
+  const qs = params.size ? `?${params.toString()}` : '';
+  const data = await fetchJson<{ events: string[] }>(
+    `/nodes/${encodeURIComponent(nodeId)}/events${qs}`,
+  );
+  return data.events || [];
+};

--- a/app/services/index.ts
+++ b/app/services/index.ts
@@ -14,4 +14,6 @@ export {
   mergePartitions,
   getTransactions,
   abortTransaction,
+  getClusterEvents,
+  getNodeEvents,
 } from './api';

--- a/app/tests/LogViewer.test.tsx
+++ b/app/tests/LogViewer.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+vi.mock('../services/api', () => ({
+  getNodes: vi.fn(),
+  getClusterEvents: vi.fn(),
+  getNodeEvents: vi.fn(),
+}))
+
+import LogViewer from '../components/internals/LogViewer'
+import { getNodes, getClusterEvents, getNodeEvents } from '../services/api'
+import { NodeStatus, type Node } from '../types'
+
+const nodes: Node[] = [
+  { id: 'n1', address: 'a', status: NodeStatus.LIVE, uptime: '1d', cpuUsage: 0, memoryUsage: 0, diskUsage: 0, dataLoad: 0, replicationLogSize: 0, hintsCount: 0 },
+]
+
+beforeEach(() => {
+  vi.resetAllMocks()
+  ;(getNodes as any).mockResolvedValue(nodes)
+  ;(getClusterEvents as any).mockResolvedValue(['c1'])
+  ;(getNodeEvents as any).mockResolvedValue(['n1e'])
+})
+
+describe('LogViewer', () => {
+  it('fetches and displays logs for cluster and node', async () => {
+    render(<LogViewer />)
+
+    await waitFor(() => {
+      expect(getNodes).toHaveBeenCalled()
+    })
+    await waitFor(() => {
+      expect(getClusterEvents).toHaveBeenCalled()
+    })
+    expect(screen.getByText('c1')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'n1' } })
+    await waitFor(() => {
+      expect(getNodeEvents).toHaveBeenCalledWith('n1')
+    })
+    expect(screen.getByText('n1e')).toBeInTheDocument()
+  })
+})

--- a/app/tests/api.test.ts
+++ b/app/tests/api.test.ts
@@ -9,6 +9,8 @@ import {
   rebalance,
   getTransactions,
   abortTransaction,
+  getClusterEvents,
+  getNodeEvents,
 } from '../services/api'
 import { vi } from 'vitest'
 
@@ -126,5 +128,19 @@ describe('api service', () => {
       'http://localhost:8000/cluster/transactions/n1/t1/abort',
       { method: 'POST' },
     )
+  })
+
+  it('getClusterEvents hits cluster events endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ events: [] }) })
+    vi.stubGlobal('fetch', fetchMock)
+    await getClusterEvents()
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/cluster/events', undefined)
+  })
+
+  it('getNodeEvents hits node events endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ events: [] }) })
+    vi.stubGlobal('fetch', fetchMock)
+    await getNodeEvents('n1')
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8000/nodes/n1/events', undefined)
   })
 })


### PR DESCRIPTION
## Summary
- add `getClusterEvents` and `getNodeEvents` API helpers
- create `<LogViewer>` component for viewing cluster/node logs
- integrate logs tab in ClusterInternals
- add Logs section to sidebar and routing in App
- test new API helpers and component
- document accessing logs

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68689db623d88331a9d62a8b7cfac1ef