### PR TITLE
Implement 2PL configurable lock strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,8 @@ client.commit_transaction(tx)
   dirty writes.
 - **Atomic increment** &ndash; the `Increment` RPC updates numeric values
   atomically using a per-key lock.
+- **Configurable locking** &ndash; pass `tx_lock_strategy="2pl"` to enable
+  pessimistic two-phase locking or `"basic"` for the original behavior.
 
 ## Dedicated Routing Tier
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -842,6 +842,8 @@ cliente.commit_transaction(tx)
   chave por vez, evitando escritas sujas.
 - **Incremento atômico** &ndash; a RPC `Increment` atualiza contadores de forma
   atômica usando um lock dedicado.
+- **Bloqueio configurável** &ndash; defina `tx_lock_strategy="2pl"` para usar
+  bloqueio pessimista em duas fases ou `"basic"` para o comportamento anterior.
 
 ## Dedicated Routing Tier
 


### PR DESCRIPTION
## Summary
- add `tx_lock_strategy` option to NodeServer
- skip lock acquisition for basic strategy
- add helper to release transaction locks
- document new option in both READMEs

## Testing
- `pytest tests/test_transactions.py -q`
- `pytest -q` *(fails: TypeError in TestClient with httpx)*

------
https://chatgpt.com/codex/tasks/task_e_6868a2fc62008331923fd26ab6b08a69