### PR TITLE
Ensure node logs reach UI

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -180,6 +180,7 @@ def time_series_metrics() -> dict:
 def cluster_events(offset: int = 0, limit: int | None = None) -> dict:
     """Return recent event log entries."""
     cluster = app.state.cluster
+    cluster.event_logger.sync()
     events = cluster.event_logger.get_events(offset=offset, limit=limit)
     return {"events": events}
 
@@ -408,6 +409,7 @@ def node_events(node_id: str, offset: int = 0, limit: int | None = None) -> dict
     logger = cluster.node_loggers.get(node_id)
     if logger is None:
         raise HTTPException(status_code=404, detail="node not found")
+    logger.sync()
     events = logger.get_events(offset=offset, limit=limit)
     return {"events": events}
 

--- a/tests/test_event_logger_sync.py
+++ b/tests/test_event_logger_sync.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+import sys
+import unittest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from database.utils.event_logger import EventLogger
+
+
+class EventLoggerSyncTest(unittest.TestCase):
+    def test_sync_reads_appended_lines(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            log_path = os.path.join(tmpdir, "log.txt")
+            writer = EventLogger(log_path)
+            reader = EventLogger(log_path)
+            writer.log("first")
+            reader.sync()
+            events = reader.get_events()
+            self.assertTrue(any("first" in e for e in events))
+            writer.close()
+            reader.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `EventLogger` to read new events from disk
- sync log files when fetching cluster or node events
- add regression test for event log sync

## Testing
- `python -m unittest tests/test_event_logger_sync.py -v`
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_686c0bea09508331864ff236c067d187