### PR TITLE
Improve partition UI info

### DIFF
--- a/app/components/Dashboard.tsx
+++ b/app/components/Dashboard.tsx
@@ -72,7 +72,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onManageNode }) => {
           {config && <TopologyView nodes={nodes} config={config} />}
       </div>
       
-      <PartitionList partitions={partitions} />
+      <PartitionList partitions={partitions} nodes={nodes} strategy={config?.partitionStrategy} />
 
       {metrics && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">

--- a/app/tests/PartitionList.test.tsx
+++ b/app/tests/PartitionList.test.tsx
@@ -1,21 +1,27 @@
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import PartitionList from '../components/dashboard/PartitionList'
-import { type Partition } from '../types'
+import { type Partition, type Node, NodeStatus } from '../types'
 
 const partitions: Partition[] = [
   { id: 'p1', primaryNodeId: 'n1', replicaNodeIds: ['n2'], keyRange: ['a', 'z'], size: 1, itemCount: 100, operationCount: 0 },
 ]
+const nodes: Node[] = [
+  { id: 'n1', address: 'addr1', status: NodeStatus.LIVE, uptime: '1d', cpuUsage: 0, memoryUsage: 0, diskUsage: 0, dataLoad: 0, replicationLogSize: 0, hintsCount: 0 },
+  { id: 'n2', address: 'addr2', status: NodeStatus.LIVE, uptime: '1d', cpuUsage: 0, memoryUsage: 0, diskUsage: 0, dataLoad: 0, replicationLogSize: 0, hintsCount: 0 },
+]
 
 describe('PartitionList', () => {
   it('renders partition table', () => {
-    render(<PartitionList partitions={partitions} />)
+    render(<PartitionList partitions={partitions} nodes={nodes} strategy="hash" />)
     expect(screen.getByText('Partitions')).toBeInTheDocument()
     expect(screen.getByText('p1')).toBeInTheDocument()
+    expect(screen.getByText('hash')).toBeInTheDocument()
+    expect(screen.getByText('n1 (addr1)')).toBeInTheDocument()
   })
 
   it('shows empty message', () => {
-    render(<PartitionList partitions={[]} />)
+    render(<PartitionList partitions={[]} nodes={[]} strategy="hash" />)
     expect(screen.getByText('No partitions found.')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
- clarify ownership and strategy in partition view
- update dashboard to pass node and strategy info
- adjust tests for new partition layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c4ddd073883319276a2d21029b5ac