### PR TITLE
Add test for hash partition split via API

### DIFF
--- a/tests/api/test_partition_management_api.py
+++ b/tests/api/test_partition_management_api.py
@@ -19,6 +19,21 @@ def _setup_range_cluster():
     return app.state.cluster
 
 
+def _setup_hash_cluster():
+    old_cluster = app.state.cluster
+    tmpdir = tempfile.mkdtemp()
+    if old_cluster:
+        old_cluster.shutdown()
+    app.state.cluster = NodeCluster(
+        base_path=tmpdir,
+        num_nodes=2,
+        replication_factor=1,
+        partition_strategy="hash",
+        num_partitions=2,
+    )
+    return app.state.cluster
+
+
 def test_split_partition_endpoint_increases_count():
     with TestClient(app) as client:
         cluster = _setup_range_cluster()
@@ -27,6 +42,22 @@ def test_split_partition_endpoint_increases_count():
             resp = client.post(
                 "/cluster/actions/split_partition",
                 params={"pid": 0, "split_key": "g"},
+            )
+            assert resp.status_code == 200
+            assert resp.json().get("status") == "ok"
+            assert cluster.num_partitions == initial + 1
+        finally:
+            cluster.shutdown()
+
+
+def test_split_partition_hash_endpoint_increases_count():
+    with TestClient(app) as client:
+        cluster = _setup_hash_cluster()
+        try:
+            initial = cluster.num_partitions
+            resp = client.post(
+                "/cluster/actions/split_partition",
+                params={"pid": 0},
             )
             assert resp.status_code == 200
             assert resp.json().get("status") == "ok"


### PR DESCRIPTION
## Summary
- ensure cluster API split action works on hash partitioning
- test splits for range and hash strategies

## Testing
- `pytest -q tests/api/test_partition_management_api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c54b96f5483319ab84e2a532584e3