### PR TITLE
Improve partition range display

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -87,6 +87,7 @@ def list_partitions() -> dict:
     """Return partition map with operation and item count stats."""
     cluster = app.state.cluster
     mapping = cluster.get_partition_map()
+    ranges = cluster.get_partition_ranges()
     stats = cluster.get_partition_stats()
     counts = cluster.get_partition_item_counts()
     parts = []
@@ -95,6 +96,7 @@ def list_partitions() -> dict:
             {
                 "id": pid,
                 "node": owner,
+                "key_range": ranges.get(pid, ("", "")),
                 "ops": stats.get(pid, 0),
                 "items": counts.get(pid, 0),
             }

--- a/app/components/dashboard/PartitionList.tsx
+++ b/app/components/dashboard/PartitionList.tsx
@@ -52,7 +52,9 @@ const PartitionList: React.FC<PartitionListProps> = ({ partitions, nodes, strate
         <thead className="text-xs text-green-400 uppercase bg-green-900/30">
           <tr>
             <th scope="col" className="px-6 py-3">Partition ID</th>
-            <th scope="col" className="px-6 py-3">Key Range</th>
+            <th scope="col" className="px-6 py-3">
+              {strategy === 'range' ? 'Key Range' : 'Hash Range'}
+            </th>
             <th scope="col" className="px-6 py-3">Owner Node</th>
             <th scope="col" className="px-6 py-3">Replicas</th>
             <th scope="col" className="px-6 py-3">Type</th>
@@ -66,7 +68,11 @@ const PartitionList: React.FC<PartitionListProps> = ({ partitions, nodes, strate
             return (
               <tr key={partition.id} className="border-b border-green-800/60 hover:bg-green-900/20">
                 <td className="px-6 py-4 font-medium text-green-100 whitespace-nowrap">{partition.id}</td>
-                <td className="px-6 py-4 font-mono text-green-400">{`[${partition.keyRange[0]}, ${partition.keyRange[1]})`}</td>
+                <td className="px-6 py-4 font-mono text-green-400">
+                  {partition.keyRange[0] || partition.keyRange[1]
+                    ? `[${partition.keyRange[0]}, ${partition.keyRange[1]})`
+                    : '-'}
+                </td>
                 <td className="px-6 py-4">
                   {owner ? `${owner.id} (${owner.address})` : partition.primaryNodeId}
                 </td>

--- a/app/services/api.ts
+++ b/app/services/api.ts
@@ -35,7 +35,7 @@ export const getPartitions = async (): Promise<Partition[]> => {
     id: p.id.toString(),
     primaryNodeId: p.node,
     replicaNodeIds: [],
-    keyRange: ['', ''],
+    keyRange: [p.key_range?.[0] ?? '', p.key_range?.[1] ?? ''],
     size: 0,
     itemCount: p.items ?? 0,
     operationCount: p.ops ?? 0,

--- a/app/tests/PartitionList.test.tsx
+++ b/app/tests/PartitionList.test.tsx
@@ -13,10 +13,10 @@ const nodes: Node[] = [
 
 describe('PartitionList', () => {
   it('renders partition table', () => {
-    render(<PartitionList partitions={partitions} nodes={nodes} strategy="hash" />)
+    render(<PartitionList partitions={partitions} nodes={nodes} strategy="range" />)
     expect(screen.getByText('Partitions')).toBeInTheDocument()
     expect(screen.getByText('p1')).toBeInTheDocument()
-    expect(screen.getByText('hash')).toBeInTheDocument()
+    expect(screen.getByText('Key Range')).toBeInTheDocument()
     expect(screen.getByText('n1 (addr1)')).toBeInTheDocument()
   })
 

--- a/tests/api/test_cluster_endpoints.py
+++ b/tests/api/test_cluster_endpoints.py
@@ -27,6 +27,8 @@ def test_cluster_partitions():
         assert len(data["partitions"]) > 0
         ids = [p["id"] for p in data["partitions"]]
         assert ids == sorted(ids)
+        for p in data["partitions"]:
+            assert "key_range" in p
 
 
 def test_time_series_metrics():

--- a/tests/api/test_dashboard_api.py
+++ b/tests/api/test_dashboard_api.py
@@ -23,6 +23,8 @@ def test_dashboard_partitions():
         data = resp.json()
         assert "partitions" in data
         assert isinstance(data["partitions"], list)
+        for p in data["partitions"]:
+            assert "key_range" in p
 
 
 def test_dashboard_time_series():


### PR DESCRIPTION
## Summary
- include key ranges in `/cluster/partitions`
- return range data from cluster depending on partition strategy
- show correct range header and value in dashboard
- update associated tests

## Testing
- `pytest -q`
- `npm --prefix app test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c587610e483318635ce2737284f18