### PR TITLE
Add success/fail alerts to node management UI

### DIFF
--- a/app/components/Management.tsx
+++ b/app/components/Management.tsx
@@ -6,6 +6,7 @@ import NodeSelector from './management/NodeSelector';
 import NodeDetail from './management/NodeDetail';
 import ClusterActions from './management/ClusterActions';
 import PartitionActions from './management/PartitionActions';
+import Alert from './common/Alert';
 
 interface ManagementProps {
   initialSelectedNodeId: string | null;
@@ -16,6 +17,7 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(initialSelectedNodeId);
   const [isLoading, setIsLoading] = useState(true);
   const [isActionLoading, setIsActionLoading] = useState(false);
+  const [alert, setAlert] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
   const fetchNodes = useCallback(async () => {
     setIsLoading(true);
@@ -52,8 +54,10 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
     try {
         await addNode();
         await fetchNodes(); // Re-fetch all nodes to get the new list
+        setAlert({ message: 'Node added', type: 'success' });
     } catch (error) {
         console.error("Failed to add node:", error);
+        setAlert({ message: 'Failed to add node', type: 'error' });
     } finally {
         setIsActionLoading(false);
     }
@@ -66,8 +70,10 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
             await removeNode(nodeId);
             setSelectedNodeId(null);
             await fetchNodes(); // Re-fetch all nodes
+            setAlert({ message: 'Node removed', type: 'success' });
         } catch (error) {
             console.error("Failed to remove node:", error);
+            setAlert({ message: 'Failed to remove node', type: 'error' });
         } finally {
             setIsActionLoading(false);
         }
@@ -79,8 +85,10 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
     try {
         const updatedNode = await stopNode(nodeId);
         handleUpdateNode(updatedNode);
+        setAlert({ message: 'Node stopped', type: 'success' });
     } catch (error) {
         console.error("Failed to stop node:", error);
+        setAlert({ message: 'Failed to stop node', type: 'error' });
     } finally {
         setIsActionLoading(false);
     }
@@ -91,8 +99,10 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
     try {
         const updatedNode = await startNode(nodeId);
         handleUpdateNode(updatedNode);
+        setAlert({ message: 'Node started', type: 'success' });
     } catch (error) {
         console.error("Failed to start node:", error);
+        setAlert({ message: 'Failed to start node', type: 'error' });
     } finally {
         setIsActionLoading(false);
     }
@@ -110,6 +120,13 @@ const Management: React.FC<ManagementProps> = ({ initialSelectedNodeId }) => {
 
   return (
     <div className="space-y-6">
+      {alert && (
+        <Alert
+          message={alert.message}
+          type={alert.type}
+          onClose={() => setAlert(null)}
+        />
+      )}
        <div>
         <h1 className="text-3xl font-bold text-white">Cluster Management</h1>
         <p className="text-green-300 mt-1">Perform administrative actions on the cluster and its nodes.</p>

--- a/app/components/common/Alert.tsx
+++ b/app/components/common/Alert.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect, useState } from 'react';
+
+interface AlertProps {
+  message: string;
+  type: 'success' | 'error';
+  onClose: () => void;
+}
+
+const Alert: React.FC<AlertProps> = ({ message, type, onClose }) => {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    setVisible(true);
+    const fade = setTimeout(() => setVisible(false), 2500);
+    const timer = setTimeout(onClose, 3000);
+    return () => {
+      clearTimeout(fade);
+      clearTimeout(timer);
+    };
+  }, [onClose]);
+
+  const base = 'fixed top-4 right-4 px-4 py-2 rounded shadow-lg transition-opacity duration-500';
+  const colors = type === 'success' ? 'bg-green-600 text-white' : 'bg-red-600 text-white';
+
+  return (
+    <div className={`${base} ${colors} ${visible ? 'opacity-100' : 'opacity-0'}`}>{message}</div>
+  );
+};
+
+export default Alert;

--- a/app/tests/Alert.test.tsx
+++ b/app/tests/Alert.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+import Alert from '../components/common/Alert'
+
+describe('Alert', () => {
+  it('calls onClose after timeout', () => {
+    vi.useFakeTimers()
+    const onClose = vi.fn()
+    render(<Alert message="done" type="success" onClose={onClose} />)
+    expect(screen.getByText('done')).toBeInTheDocument()
+    vi.advanceTimersByTime(3000)
+    expect(onClose).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- show short-lived alerts on node management actions
- implement reusable `Alert` component
- test `Alert` component behavior

## Testing
- `npm test`
- `pytest -k node_start_stop -q`

------
https://chatgpt.com/codex/tasks/task_e_686d07d61a8c8331997e1a28d8c712c6