### PR TITLE
Add recommendation data generator and cluster example

### DIFF
--- a/examples/data_generators.py
+++ b/examples/data_generators.py
@@ -25,3 +25,23 @@ def generate_range_items(num: int = 10):
     for i in range(1, num + 1):
         letter = chr(ord('a') + (i - 1) % 26)
         yield compose_key(letter, str(i)), f"v{i}"
+
+
+PREFERENCES = [
+    "sports",
+    "movies",
+    "music",
+    "travel",
+    "tech",
+    "fashion",
+]
+
+
+def generate_recommendation_data(num: int = 10):
+    """Yield user IDs mapped to preference vectors and recent items."""
+    for i in range(1, num + 1):
+        user_id = f"u{i}"
+        pref = random.choice(PREFERENCES)
+        recent = random.sample(range(100), k=3)
+        value = json.dumps({"preference": pref, "recent": recent})
+        yield user_id, value

--- a/examples/recommendation_cluster.py
+++ b/examples/recommendation_cluster.py
@@ -1,0 +1,52 @@
+import json
+import sys
+import os
+
+# Ensure project root is on the import path just like the tests do
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.main import app
+from database.replication import NodeCluster
+from examples.service_runner import start_frontend
+from examples.data_generators import generate_recommendation_data
+
+
+def main() -> None:
+    app.router.on_startup.clear()
+    cluster = NodeCluster(
+        base_path="/tmp/recommendation_cluster",
+        num_nodes=3,
+        index_fields=["preference"],
+    )
+
+    print("Partition map:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        print(f"  P{pid}: {owner}")
+
+    for key, value in generate_recommendation_data(50):
+        cluster.put(0, key, value)
+        pref = json.loads(value)["preference"]
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        idx_owner = cluster.get_index_owner("preference", pref)
+        print(
+            f"Stored {key} pref={pref} in partition {pid} on {owner}; index on {idx_owner}"
+        )
+
+    sports_users = cluster.secondary_query("preference", "sports")
+    if sports_users:
+        print(f"Users who prefer sports: {', '.join(sports_users)}")
+
+    app.state.cluster = cluster
+    front_proc = start_frontend()
+    print("API running at http://localhost:8000")
+    try:
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
+    finally:
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend `examples/data_generators.py` with `generate_recommendation_data`
- add `examples/recommendation_cluster.py` demonstrating indexed recommendation data

## Testing
- `pytest -q` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_686d3b7f24f083319ce63d230310b0b5