### PR TITLE
Add session generator & cluster example

### DIFF
--- a/examples/data_generators.py
+++ b/examples/data_generators.py
@@ -5,6 +5,8 @@ from database.clustering.partitioning import compose_key
 
 COLORS = ["red", "blue", "green", "yellow", "purple"]
 
+LANGS = ["en", "es", "pt", "de"]
+
 
 def generate_index_items(num: int = 10):
     """Yield keys and JSON values with a random color field."""
@@ -25,3 +27,15 @@ def generate_range_items(num: int = 10):
     for i in range(1, num + 1):
         letter = chr(ord('a') + (i - 1) % 26)
         yield compose_key(letter, str(i)), f"v{i}"
+
+
+def generate_session_data(num: int = 10):
+    """Yield session_id and JSON-encoded user preference records."""
+    for i in range(1, num + 1):
+        session_id = f"s{i}"
+        user = f"user{i}"
+        prefs = {
+            "theme": random.choice(COLORS),
+            "lang": random.choice(LANGS),
+        }
+        yield session_id, json.dumps({"user": user, "prefs": prefs})

--- a/examples/session_cluster.py
+++ b/examples/session_cluster.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+# Ensure project root is on the import path just like the tests do
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.main import app
+from database.replication import NodeCluster
+from examples.service_runner import start_frontend
+from examples.data_generators import generate_session_data
+
+
+def main() -> None:
+    app.router.on_startup.clear()
+    cluster = NodeCluster(
+        base_path="/tmp/session_cluster",
+        num_nodes=3,
+        partition_strategy="hash",
+        replication_factor=2,
+        partitions_per_node=32,
+        consistency_mode="lww",
+    )
+
+    print("Partition map:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        print(f"  P{pid}: {owner}")
+
+    for sid, value in generate_session_data(50):
+        cluster.put(0, sid, value)
+        pid = cluster.get_partition_id(sid)
+        owner = cluster.get_partition_map().get(pid)
+        print(f"Stored {sid} in partition {pid} on {owner}")
+
+    app.state.cluster = cluster
+    front_proc = start_frontend()
+    print("API running at http://localhost:8000")
+    try:
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
+    finally:
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extend data_generators with `generate_session_data`
- add `session_cluster.py` example showing session placement

## Testing
- `pip install -q -r requirements.txt`
- `python -m pytest -q` *(fails: 2 failed, 167 passed)*

------
https://chatgpt.com/codex/tasks/task_e_686d3b7954f483319140aff99bc0db23