### PR TITLE
Add ecommerce example and data generators

### DIFF
--- a/examples/data_generators.py
+++ b/examples/data_generators.py
@@ -25,3 +25,24 @@ def generate_range_items(num: int = 10):
     for i in range(1, num + 1):
         letter = chr(ord('a') + (i - 1) % 26)
         yield compose_key(letter, str(i)), f"v{i}"
+
+
+def generate_cart_items(num: int = 10):
+    """Yield cart id keys mapping to a JSON list of product ids and quantities."""
+    for i in range(1, num + 1):
+        key = f"cart{i}"
+        items = []
+        for _ in range(random.randint(1, 5)):
+            pid = f"p{random.randint(1, num)}"
+            qty = random.randint(1, 3)
+            items.append({"id": pid, "qty": qty})
+        yield key, json.dumps(items)
+
+
+def generate_product_catalog(num: int = 10):
+    """Yield product id keys mapping to JSON objects with name and price."""
+    for i in range(1, num + 1):
+        key = f"p{i}"
+        price = round(random.uniform(5.0, 100.0), 2)
+        value = json.dumps({"name": f"Product {i}", "price": price})
+        yield key, value

--- a/examples/ecommerce_cluster.py
+++ b/examples/ecommerce_cluster.py
@@ -1,0 +1,55 @@
+import json
+import sys
+import os
+
+# Ensure project root is on the import path just like the tests do
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.main import app
+from database.replication import NodeCluster
+from examples.service_runner import start_frontend
+from examples.data_generators import generate_product_catalog, generate_cart_items
+
+
+def main() -> None:
+    app.router.on_startup.clear()
+    cluster = NodeCluster(
+        base_path="/tmp/ecommerce_cluster",
+        num_nodes=3,
+        partition_strategy="hash",
+        replication_factor=2,
+        partitions_per_node=32,
+    )
+
+    print("Partition map:")
+    for pid, owner in sorted(cluster.get_partition_map().items()):
+        print(f"  P{pid}: {owner}")
+
+    print("Loading catalog...")
+    for key, value in generate_product_catalog(20):
+        cluster.put(0, key, value)
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        attrs = json.loads(value)
+        print(f"Catalog product {key} {attrs} in partition {pid} on {owner}")
+
+    print("Loading carts...")
+    for key, value in generate_cart_items(10):
+        cluster.put(0, key, value)
+        pid = cluster.get_partition_id(key)
+        owner = cluster.get_partition_map().get(pid)
+        print(f"Cart {key} in partition {pid} on {owner}")
+
+    app.state.cluster = cluster
+    front_proc = start_frontend()
+    print("API running at http://localhost:8000")
+    try:
+        import uvicorn
+        uvicorn.run("api.main:app", port=8000)
+    finally:
+        front_proc.terminate()
+        cluster.shutdown()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create helpers to generate product catalog and cart items
- provide an example `ecommerce_cluster.py` that loads the generators into a cluster

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3b7e55a08331b4153652bb6deca2