### PR TITLE
Fix compaction iteration and replication log race

### DIFF
--- a/database/lsm/sstable.py
+++ b/database/lsm/sstable.py
@@ -265,7 +265,7 @@ class SSTableManager:
 
         sorted_merged_items = []
         for k, vers in sorted(final_merged_data.items()):
-            for val, vc in vers:
+            for val, vc, *_ in vers:
                 sorted_merged_items.append((k, val, vc))
 
         # Escreve o novo SSTable compactado

--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -789,7 +789,7 @@ class ReplicaService(replication_pb2_grpc.ReplicaServicer):
                 self.Put(req, context)
 
         ops = []
-        for op_id, (key, value, ts) in self._node.replication_log.items():
+        for op_id, (key, value, ts) in list(self._node.replication_log.items()):
             origin, seq = op_id.split(":")
             seq = int(seq)
             seen = last_seen.get(origin, 0)


### PR DESCRIPTION
## Summary
- handle version tuples with optional fields when compacting SSTables
- iterate over a copy of `replication_log` to avoid runtime errors

## Testing
- `pytest tests/test_lsm_db.py::SimpleLSMDBTest::test_delete_and_compaction -q`

------
https://chatgpt.com/codex/tasks/task_e_686d41e98854833189b5d36f555fa89d