### PR TITLE
Add query-based filtering to DataBrowser

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -431,7 +431,9 @@ def health() -> dict:
 
 
 @app.get("/data/records")
-def list_records_endpoint(offset: int = 0, limit: int | None = None) -> dict:
+def list_records_endpoint(
+    offset: int = 0, limit: int | None = None, query: str | None = None
+) -> dict:
     """Return records stored in the cluster with optional pagination."""
     cluster = app.state.cluster
     records = [
@@ -440,7 +442,7 @@ def list_records_endpoint(offset: int = 0, limit: int | None = None) -> dict:
             "clustering_key": ck,
             "value": val,
         }
-        for pk, ck, val in cluster.list_records(offset=offset, limit=limit)
+        for pk, ck, val in cluster.list_records(offset=offset, limit=limit, query=query)
     ]
     return {"records": records}
 

--- a/app/components/DataBrowser.tsx
+++ b/app/components/DataBrowser.tsx
@@ -8,7 +8,6 @@ import Pagination from './databrowser/Pagination';
 
 const DataBrowser: React.FC = () => {
   const [records, setRecords] = useState<UserRecord[]>([]);
-  const [filteredRecords, setFilteredRecords] = useState<UserRecord[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [editingRecord, setEditingRecord] = useState<UserRecord | null>(null);
@@ -22,32 +21,24 @@ const DataBrowser: React.FC = () => {
     setIsLoading(true);
     try {
       const offset = (currentPage - 1) * pageSize;
-      const recordsData = await databaseService.getUserRecords(offset, pageSize);
+      const recordsData = await databaseService.getUserRecords(
+        offset,
+        pageSize,
+        searchTerm,
+      );
       setRecords(recordsData);
-      setFilteredRecords(recordsData);
       setHasNext(recordsData.length === pageSize);
     } catch (error) {
       console.error('Failed to fetch user records:', error);
     } finally {
       setIsLoading(false);
     }
-  }, [currentPage, pageSize]);
+  }, [currentPage, pageSize, searchTerm]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData]);
 
-  useEffect(() => {
-    const lowercasedFilter = searchTerm.toLowerCase();
-    const filteredData = records.filter(item => {
-      return (
-        item.partitionKey.toLowerCase().includes(lowercasedFilter) ||
-        item.clusteringKey?.toLowerCase().includes(lowercasedFilter) ||
-        item.value.toLowerCase().includes(lowercasedFilter)
-      );
-    });
-    setFilteredRecords(filteredData);
-  }, [searchTerm, records]);
 
 
   const handleOpenCreateModal = () => {
@@ -103,7 +94,7 @@ const DataBrowser: React.FC = () => {
         </div>
       ) : (
         <>
-          <DataTable records={filteredRecords} onEdit={handleOpenEditModal} onDelete={handleDeleteRecord} />
+          <DataTable records={records} onEdit={handleOpenEditModal} onDelete={handleDeleteRecord} />
           <Pagination
             currentPage={currentPage}
             onPageChange={setCurrentPage}
@@ -115,7 +106,7 @@ const DataBrowser: React.FC = () => {
         </>
       )}
       
-      <DataEditorModal 
+      <DataEditorModal
         isOpen={isModalOpen}
         onClose={handleCloseModal}
         onSave={handleSaveRecord}
@@ -124,5 +115,4 @@ const DataBrowser: React.FC = () => {
     </div>
   );
 };
-
 export default DataBrowser;

--- a/app/services/databaseService.ts
+++ b/app/services/databaseService.ts
@@ -4,11 +4,15 @@ import { fetchJson } from './request';
 export const getUserRecords = async (
   offset = 0,
   limit = 50,
+  query = '',
 ): Promise<UserRecord[]> => {
   const params = new URLSearchParams({
     offset: String(offset),
     limit: String(limit),
   });
+  if (query) {
+    params.append('query', query);
+  }
   const data = await fetchJson<{ records: { partition_key: string; clustering_key: string | null; value: string }[] }>(`/data/records?${params.toString()}`);
   return data.records.map(r => ({
     partitionKey: r.partition_key,

--- a/app/services/storageService.ts
+++ b/app/services/storageService.ts
@@ -22,7 +22,8 @@ export const getSstableEntries = (nodeId: string, sstableId: string): Promise<St
 export const getUserRecords = (
   offset = 0,
   limit = 50,
-): Promise<UserRecord[]> => db.getUserRecords(offset, limit);
+  query = '',
+): Promise<UserRecord[]> => db.getUserRecords(offset, limit, query);
 export const saveUserRecord = (record: UserRecord): Promise<UserRecord> => db.saveUserRecord(record);
 export const deleteUserRecord = (partitionKey: string, clusteringKey: string): Promise<void> => db.deleteUserRecord(partitionKey, clusteringKey);
 

--- a/database/replication/replication.py
+++ b/database/replication/replication.py
@@ -1143,7 +1143,7 @@ class NodeCluster:
         return {k: [tpl for tpl in v if tpl[0] != TOMBSTONE] for k, v in merged.items()}
 
     def list_records(
-        self, offset: int = 0, limit: int | None = None
+        self, offset: int = 0, limit: int | None = None, query: str | None = None
     ) -> list[tuple[str, str | None, object]]:
         """Return records stored across the cluster with optional slicing.
 
@@ -1163,6 +1163,7 @@ class NodeCluster:
                     continue
 
         records: list[tuple[str, str | None, object]] = []
+        q = (query or "").lower()
         for key in sorted(key_set):
             pk, ck = self._split_key_components(key)
             try:
@@ -1170,6 +1171,12 @@ class NodeCluster:
             except Exception:
                 continue
             if value is None or value == TOMBSTONE:
+                continue
+            if q and not (
+                q in pk.lower()
+                or (ck and q in ck.lower())
+                or q in str(value).lower()
+            ):
                 continue
             records.append((pk, ck, value))
 

--- a/tests/api/test_data_records_api.py
+++ b/tests/api/test_data_records_api.py
@@ -64,3 +64,21 @@ def test_records_pagination():
         assert len(data) == 2
         assert data[0]["partition_key"] == "pk2"
         assert data[1]["partition_key"] == "pk3"
+
+
+def test_records_query_filter():
+    with TestClient(app) as client:
+        for i in range(3):
+            resp = client.post(
+                "/data/records",
+                json={"partitionKey": f"foo{i}", "clusteringKey": None, "value": f"v{i}"},
+            )
+            assert resp.status_code == 200
+
+        # allow log flush
+        time.sleep(0.1)
+        resp = client.get("/data/records", params={"query": "foo1"})
+        assert resp.status_code == 200
+        data = resp.json().get("records", [])
+        assert len(data) == 1
+        assert data[0]["partition_key"] == "foo1"


### PR DESCRIPTION
## Summary
- enable query filtering via API in `/data/records`
- support filtering in NodeCluster.list_records
- pass query from database service when fetching records
- reload data when search term changes in DataBrowser
- update UI and backend tests for filtering

## Testing
- `npm run test`
- `pytest tests/api/test_data_records_api.py::test_records_query_filter -q`

------
https://chatgpt.com/codex/tasks/task_e_686d539e131c8331a086966fc221caf4