### PR TITLE
Fix cross-platform temp paths

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,6 +5,8 @@ from database.replication import NodeCluster
 from database.replication.replica import replication_pb2
 from concurrent.futures import ThreadPoolExecutor
 import time
+import os
+import tempfile
 
 app = FastAPI()
 
@@ -28,7 +30,9 @@ class Record(BaseModel):
 def startup_event() -> None:
     """Initialize the cluster when the API starts."""
     app.state.cluster_start = time.time()
-    app.state.cluster = NodeCluster(base_path="/tmp/api_cluster", num_nodes=3)
+    app.state.cluster = NodeCluster(
+        base_path=os.path.join(tempfile.gettempdir(), "api_cluster"), num_nodes=3
+    )
 
 
 @app.on_event("shutdown")

--- a/examples/ecommerce_cluster.py
+++ b/examples/ecommerce_cluster.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,7 +15,7 @@ from examples.data_generators import generate_product_catalog, generate_cart_ite
 def main() -> None:
     app.router.on_startup.clear()
     cluster = NodeCluster(
-        base_path="/tmp/ecommerce_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "ecommerce_cluster"),
         num_nodes=3,
         partition_strategy="hash",
         replication_factor=2,

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,7 +14,7 @@ from examples.data_generators import generate_hash_items
 def main() -> None:
     app.router.on_startup.clear()
     cluster = NodeCluster(
-        base_path="/tmp/hash_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "hash_cluster"),
         num_nodes=3,
         partition_strategy="hash",
         replication_factor=2,

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,7 +15,7 @@ from examples.data_generators import generate_index_items
 def main() -> None:
     app.router.on_startup.clear()
     cluster = NodeCluster(
-        base_path="/tmp/index_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "index_cluster"),
         num_nodes=3,
         index_fields=["color"],
     )

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -15,7 +16,7 @@ def main() -> None:
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
     cluster = NodeCluster(
-        base_path="/tmp/range_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "range_cluster"),
         num_nodes=3,
         key_ranges=ranges,
     )

--- a/examples/recommendation_cluster.py
+++ b/examples/recommendation_cluster.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,7 +15,7 @@ from examples.data_generators import generate_recommendation_data
 def main() -> None:
     app.router.on_startup.clear()
     cluster = NodeCluster(
-        base_path="/tmp/recommendation_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "recommendation_cluster"),
         num_nodes=3,
         index_fields=["preference"],
     )

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -9,13 +9,14 @@ from api.main import app
 from database.replication import NodeCluster
 from examples.service_runner import start_frontend
 from examples.data_generators import generate_hash_items
+import tempfile
 
 
 def main() -> None:
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
     cluster = NodeCluster(
-        base_path="/tmp/registry_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "registry_cluster"),
         num_nodes=2,
         key_ranges=ranges,
         start_router=True,

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,7 +14,7 @@ from examples.data_generators import generate_hash_items
 def main() -> None:
     app.router.on_startup.clear()
     cluster = NodeCluster(
-        base_path="/tmp/router_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "router_cluster"),
         num_nodes=2,
         start_router=True,
     )

--- a/examples/session_cluster.py
+++ b/examples/session_cluster.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,7 +14,7 @@ from examples.data_generators import generate_session_data
 def main() -> None:
     app.router.on_startup.clear()
     cluster = NodeCluster(
-        base_path="/tmp/session_cluster",
+        base_path=os.path.join(tempfile.gettempdir(), "session_cluster"),
         num_nodes=3,
         partition_strategy="hash",
         replication_factor=2,


### PR DESCRIPTION
## Summary
- use `tempfile.gettempdir()` in NodeCluster examples and API entrypoint

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5a6a8988833185a3df5c30589b25