### PR TITLE
Fix dictionary mutation in peer iteration

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -1127,7 +1127,7 @@ class NodeServer:
         if self.clients_by_id:
             return [
                 (c.host, c.port, node_id, c)
-                for node_id, c in self.clients_by_id.items()
+                for node_id, c in list(self.clients_by_id.items())
             ]
         return [
             (c.host, c.port, f"{c.host}:{c.port}", c)
@@ -1384,9 +1384,9 @@ class NodeServer:
     def get_replication_status(self):
         """Return last seen sequence numbers and hint counts."""
 
-        hints_count = {peer: len(ops) for peer, ops in self.hints.items()}
+        hints_count = {peer: len(ops) for peer, ops in list(self.hints.items())}
         return replication_pb2.ReplicationStatusResponse(
-            last_seen={peer: int(seq) for peer, seq in self.last_seen.items()},
+            last_seen={peer: int(seq) for peer, seq in list(self.last_seen.items())},
             hints=hints_count,
         )
 


### PR DESCRIPTION
## Summary
- prevent `dictionary changed size during iteration` errors
- copy peer lists before iterating in gRPC server
- do the same when building replication status

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q` *(fails: RPC connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686d5f7f49688331ac1d8e8e7798ac79