### PR TITLE
Add unique suffix to example clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ A standalone gRPC router can relay all client requests to the correct node. Star
 from replication import NodeCluster
 from replica.client import GRPCRouterClient
 
-cluster = NodeCluster('/tmp/router_cluster', num_nodes=3,
+cluster = NodeCluster('/tmp/router_cluster_<id>', num_nodes=3,
                       partition_strategy='hash',
                       start_router=True, router_port=7000)
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -492,7 +492,7 @@ de faixas em `key_ranges` ao criar o cluster:
 from replication import NodeCluster
 
 ranges = [('a', 'm'), ('m', None)]  # exemplo
-cluster = NodeCluster('/tmp/range_cluster', num_nodes=2, key_ranges=ranges)
+cluster = NodeCluster('/tmp/range_cluster_<id>', num_nodes=2, key_ranges=ranges)
 ```
 
 Cada tupla define o início e o fim (exclusivo) de uma faixa. No exemplo
@@ -511,7 +511,7 @@ Cada partição corresponde a um nó (ou réplica) responsável pelo armazenamen
 ```python
 from replication import NodeCluster
 
-cluster = NodeCluster('/tmp/hash_cluster', num_nodes=3,
+cluster = NodeCluster('/tmp/hash_cluster_<id>', num_nodes=3,
                       partition_strategy='hash',
                       replication_factor=1)
 ```
@@ -547,7 +547,7 @@ as variações retornando o valor mais recente.
 ```python
 from replication import NodeCluster
 
-cluster = NodeCluster('/tmp/hash_cluster', num_nodes=3,
+cluster = NodeCluster('/tmp/hash_cluster_<id>', num_nodes=3,
                       partition_strategy='hash')
 cluster.enable_salt('hotkey', buckets=4)
 
@@ -855,7 +855,7 @@ it using `GRPCRouterClient`:
 from replication import NodeCluster
 from replica.client import GRPCRouterClient
 
-cluster = NodeCluster('/tmp/router_cluster', num_nodes=3,
+cluster = NodeCluster('/tmp/router_cluster_<id>', num_nodes=3,
                       partition_strategy='hash',
                       start_router=True, router_port=7000)
 

--- a/examples/ecommerce_cluster.py
+++ b/examples/ecommerce_cluster.py
@@ -2,6 +2,7 @@ import json
 import sys
 import os
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,8 +15,9 @@ from examples.data_generators import generate_product_catalog, generate_cart_ite
 
 def main() -> None:
     app.router.on_startup.clear()
+    cluster_name = f"ecommerce_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "ecommerce_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=3,
         partition_strategy="hash",
         replication_factor=2,

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,8 +14,9 @@ from examples.data_generators import generate_hash_items
 
 def main() -> None:
     app.router.on_startup.clear()
+    cluster_name = f"hash_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "hash_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=3,
         partition_strategy="hash",
         replication_factor=2,

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -2,6 +2,7 @@ import json
 import sys
 import os
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,8 +15,9 @@ from examples.data_generators import generate_index_items
 
 def main() -> None:
     app.router.on_startup.clear()
+    cluster_name = f"index_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "index_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=3,
         index_fields=["color"],
     )

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -2,6 +2,7 @@ import json
 import sys
 import os
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -15,8 +16,9 @@ from examples.data_generators import generate_range_items
 def main() -> None:
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
+    cluster_name = f"range_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "range_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=3,
         key_ranges=ranges,
     )

--- a/examples/recommendation_cluster.py
+++ b/examples/recommendation_cluster.py
@@ -2,6 +2,7 @@ import json
 import sys
 import os
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -14,8 +15,9 @@ from examples.data_generators import generate_recommendation_data
 
 def main() -> None:
     app.router.on_startup.clear()
+    cluster_name = f"recommendation_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "recommendation_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=3,
         index_fields=["preference"],
     )

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -1,6 +1,7 @@
 import json
 import sys
 import os
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -15,8 +16,9 @@ import tempfile
 def main() -> None:
     app.router.on_startup.clear()
     ranges = [("a", "m"), ("m", "z")]
+    cluster_name = f"registry_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "registry_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=2,
         key_ranges=ranges,
         start_router=True,

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -1,6 +1,7 @@
 import sys
 import os
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,8 +14,9 @@ from examples.data_generators import generate_hash_items
 
 def main() -> None:
     app.router.on_startup.clear()
+    cluster_name = f"router_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "router_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=2,
         start_router=True,
     )

--- a/examples/session_cluster.py
+++ b/examples/session_cluster.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import tempfile
+import uuid
 
 # Ensure project root is on the import path just like the tests do
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
@@ -13,8 +14,9 @@ from examples.data_generators import generate_session_data
 
 def main() -> None:
     app.router.on_startup.clear()
+    cluster_name = f"session_cluster_{uuid.uuid4().hex[:6]}"
     cluster = NodeCluster(
-        base_path=os.path.join(tempfile.gettempdir(), "session_cluster"),
+        base_path=os.path.join(tempfile.gettempdir(), cluster_name),
         num_nodes=3,
         partition_strategy="hash",
         replication_factor=2,


### PR DESCRIPTION
## Summary
- add `uuid4` suffix for temporary cluster names
- note unique names in README docs

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -s tests -v` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686e6e4081548331888c932372c0ea9c