### PR TITLE
Fix tests by improving gRPC startup and SSTable reporting

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -1487,6 +1487,8 @@ class NodeServer:
                 # File may have been deleted by compaction, skip it
                 continue
 
+        return tables
+
     def get_sstable_content(self, sstable_id: str):
         """Return all entries stored in ``sstable_id``."""
         entries = []

--- a/tests/test_registry_node_changes.py
+++ b/tests/test_registry_node_changes.py
@@ -22,7 +22,10 @@ class RegistryNodeChangesTest(unittest.TestCase):
                 use_registry=True,
             )
             try:
-                time.sleep(0.5)
+                # give the gRPC services a moment to start before issuing
+                # requests. slower machines may require a slightly longer
+                # pause for the underlying servers to bind to their ports.
+                time.sleep(1.0)
                 channel = grpc.insecure_channel("localhost:9100")
                 stub = metadata_pb2_grpc.MetadataServiceStub(channel)
 

--- a/tests/test_replica_service.py
+++ b/tests/test_replica_service.py
@@ -261,6 +261,8 @@ class StorageRPCTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             node = NodeServer(db_path=tmpdir, port=9103, node_id="A", peers=[])
             node.server.start()
+            # ensure the server is fully bound before issuing RPCs
+            time.sleep(0.1)
             try:
                 node.db.put("k1", "v1")
                 node.db.put("k2", "v2")


### PR DESCRIPTION
## Summary
- make registry change tests wait longer for the router to start
- ensure `NodeServer.get_sstables` returns the table list
- wait briefly after starting the replica service in tests

## Testing
- `pytest -q tests/test_replica_service.py::StorageRPCTest::test_get_sstables_rpc tests/test_registry_node_changes.py::RegistryNodeChangesTest::test_registry_reports_node_changes`

------
https://chatgpt.com/codex/tasks/task_e_686e8c7c47b083318b9e6f05dd0b7146