### PR TITLE
Update Docker entrypoint and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Install frontend dependencies
 RUN cd app && npm install --legacy-peer-deps
 
-CMD ["python", "examples/hash_cluster.py"]
+EXPOSE 50051 8000
+
+ENTRYPOINT ["python", "start_node.py"]

--- a/README.md
+++ b/README.md
@@ -583,3 +583,18 @@ This starts `hash_cluster.py`, which also launches the API and React UI in the b
 ```bash
 docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
 ```
+
+## Running a single node with Docker
+
+You can also start an individual `NodeServer` container using environment
+variables to configure ports and other settings:
+
+```bash
+docker build -t py_db .
+docker run -e NODE_ID=node1 -e GRPC_PORT=50051 -e API_PORT=8000 \
+           -p 50051:50051 -p 8000:8000 py_db
+```
+
+Set `PEERS` to a comma‑separated list of `host:port` pairs when connecting
+multiple containers. Optional variables like `DATA_DIR`, `REGISTRY_HOST` and
+`REGISTRY_PORT` are also respected by `start_node.py`.

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -927,3 +927,18 @@ Esse comando inicia o `hash_cluster.py`, que lança a interface React em segundo
 docker run -p 8000:8000 -p 5173:5173 py_db python examples/range_cluster.py
 ```
 
+## Executando um único nó com Docker
+
+Também é possível iniciar apenas um `NodeServer` utilizando variáveis de
+ambiente para configurar portas e outras opções:
+
+```bash
+docker build -t py_db .
+docker run -e NODE_ID=node1 -e GRPC_PORT=50051 -e API_PORT=8000 \
+           -p 50051:50051 -p 8000:8000 py_db
+```
+
+Defina `PEERS` com uma lista separada por vírgulas de `host:porta` ao conectar
+vários contêineres. Variáveis opcionais como `DATA_DIR`, `REGISTRY_HOST` e
+`REGISTRY_PORT` também são reconhecidas pelo `start_node.py`.
+


### PR DESCRIPTION
## Summary
- update Dockerfile entrypoint and expose ports
- document how to run a node via Docker in README and README_pt_BR

## Testing
- `pip install -q -r requirements.txt`
- `pytest -k start_node -q`

------
https://chatgpt.com/codex/tasks/task_e_686f0e3150488331b932a126e7a88215