### PR TITLE
Add Docker Compose instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,18 +599,26 @@ Set `PEERS` to a comma‑separated list of `host:port` pairs when connecting
 multiple containers. Optional variables like `DATA_DIR`, `REGISTRY_HOST` and
 `REGISTRY_PORT` are also respected by `start_node.py`.
 
-## Running a cluster with Docker Compose
+## Running with Docker Compose
 
-The repository includes a `docker-compose.yml` that starts the metadata registry and three nodes. Build the images and launch the cluster with:
+The repository ships with a `docker-compose.yml` that builds the image and
+starts a metadata registry together with three nodes. Launch everything with:
 
 ```bash
 docker compose up --build
 ```
 
-Once running, each node exposes both its API and gRPC port on the host:
+All services bind to `0.0.0.0` so the containers can communicate on the Docker
+network. After startup the dashboards are available at:
 
-- node1: `http://localhost:8001` / `50051`
-- node2: `http://localhost:8002` / `50052`
-- node3: `http://localhost:8003` / `50053`
+- node1: [http://localhost:8001](http://localhost:8001) (gRPC `50051`)
+- node2: [http://localhost:8002](http://localhost:8002) (gRPC `50052`)
+- node3: [http://localhost:8003](http://localhost:8003) (gRPC `50053`)
 
-The registry service listens on port `9100`.
+Need more nodes? Duplicate the service definition or scale it with:
+
+```bash
+docker compose up --scale node=4
+```
+
+The registry service listens on [http://localhost:9100](http://localhost:9100).

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -942,3 +942,28 @@ Defina `PEERS` com uma lista separada por vírgulas de `host:porta` ao conectar
 vários contêineres. Variáveis opcionais como `DATA_DIR`, `REGISTRY_HOST` e
 `REGISTRY_PORT` também são reconhecidas pelo `start_node.py`.
 
+## Executando com Docker Compose
+
+O repositório traz um `docker-compose.yml` que constrói a imagem e inicia o
+registro de metadados junto com três nós. Execute tudo com:
+
+```bash
+docker compose up --build
+```
+
+Todos os serviços escutam em `0.0.0.0`, permitindo que os contêineres conversem
+entre si. Os painéis podem ser acessados em:
+
+- node1: [http://localhost:8001](http://localhost:8001) (gRPC `50051`)
+- node2: [http://localhost:8002](http://localhost:8002) (gRPC `50052`)
+- node3: [http://localhost:8003](http://localhost:8003) (gRPC `50053`)
+
+Para adicionar novos nós duplique a definição no compose ou utilize:
+
+```bash
+docker compose up --scale node=4
+```
+
+O serviço de registro fica disponível em
+[http://localhost:9100](http://localhost:9100).
+


### PR DESCRIPTION
## Summary
- document how to run the project with Docker Compose in both languages

## Testing
- `python -m unittest discover -s tests -v` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686f15726a208331a6760432a4bf97ea