### PR TITLE
Add graceful shutdown handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,7 @@ Once running, each node exposes both its API and gRPC port on the host:
 - node3: `http://localhost:8003` / `50053`
 
 The registry service listens on port `9100`.
+
+Stopping the container (for example with `docker stop`) sends `SIGTERM` to the
+process. `start_node.py` registers a handler for this signal so each node
+finishes background tasks and shuts down cleanly.

--- a/start_node.py
+++ b/start_node.py
@@ -10,6 +10,7 @@ DATA_DIR, PEERS, REGISTRY_HOST and REGISTRY_PORT when set.
 
 import argparse
 import os
+import signal
 from typing import List, Tuple
 
 from database.replication.replica.grpc_server import NodeServer
@@ -57,6 +58,7 @@ def main(argv: List[str] | None = None) -> None:
         registry_host=args.registry_host,
         registry_port=args.registry_port,
     )
+    signal.signal(signal.SIGTERM, lambda *_: node.stop())
     node.start()
 
 


### PR DESCRIPTION
## Summary
- trap SIGTERM in `start_node.py` and call `node.stop()`
- mention graceful shutdown in README

## Testing
- `pytest tests/test_replication_log_file.py::ReplicationLogFileTest::test_log_persisted_and_loaded -q`

------
https://chatgpt.com/codex/tasks/task_e_686f1587b22c8331b2c1afee9b9d6dc8