### PR TITLE
Update NodeServer doc and container examples

### DIFF
--- a/database/replication/replica/grpc_server.py
+++ b/database/replication/replica/grpc_server.py
@@ -915,7 +915,13 @@ class HeartbeatService(replication_pb2_grpc.HeartbeatServiceServicer):
 
 
 class NodeServer:
-    """Encapsulates gRPC server and replication logic for a node."""
+    """Encapsulates gRPC server and replication logic for a node.
+
+    The ``host`` parameter controls which network interface the gRPC server
+    binds to. It defaults to ``localhost`` for local development. When running
+    inside Docker or similar container environments, set ``host="0.0.0.0"`` so
+    the service is reachable from outside the container.
+    """
 
     local_seq: int
     last_seen: dict[str, int]

--- a/examples/ecommerce_cluster.py
+++ b/examples/ecommerce_cluster.py
@@ -48,7 +48,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/hash_cluster.py
+++ b/examples/hash_cluster.py
@@ -38,7 +38,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/index_cluster.py
+++ b/examples/index_cluster.py
@@ -40,7 +40,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/range_cluster.py
+++ b/examples/range_cluster.py
@@ -40,7 +40,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/recommendation_cluster.py
+++ b/examples/recommendation_cluster.py
@@ -45,7 +45,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/registry_cluster.py
+++ b/examples/registry_cluster.py
@@ -43,7 +43,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/router_cluster.py
+++ b/examples/router_cluster.py
@@ -35,7 +35,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()

--- a/examples/session_cluster.py
+++ b/examples/session_cluster.py
@@ -40,7 +40,7 @@ def main() -> None:
     print("API running at http://localhost:8000")
     try:
         import uvicorn
-        uvicorn.run("api.main:app", port=8000)
+        uvicorn.run("api.main:app", host="0.0.0.0", port=8000)
     finally:
         front_proc.terminate()
         cluster.shutdown()


### PR DESCRIPTION
## Summary
- document Docker host setting in `NodeServer`
- expose API examples on `0.0.0.0` for container usage
- clarify default host in NodeServer docstring

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f159061888331870c23f121d22f90